### PR TITLE
fix: fix wrong spanish error message in validator

### DIFF
--- a/go.mod
+++ b/go.mod
@@ -26,7 +26,7 @@ require (
 )
 
 require (
-	github.com/BeyondTrust/go-client-library-passwordsafe v0.14.1
+	github.com/BeyondTrust/go-client-library-passwordsafe v0.14.2
 	github.com/agext/levenshtein v1.2.2 // indirect
 	github.com/apparentlymart/go-textseg/v15 v15.0.0 // indirect
 	github.com/fatih/color v1.13.0 // indirect

--- a/go.sum
+++ b/go.sum
@@ -1,5 +1,5 @@
-github.com/BeyondTrust/go-client-library-passwordsafe v0.14.1 h1:jUBIBDX93tX0VsQrKxvG5e5eOrZ7LQy99cshFmDAdWM=
-github.com/BeyondTrust/go-client-library-passwordsafe v0.14.1/go.mod h1:72FMrpiz1fUSiIIIAXiCzQ55Y83spsu2jl5n/Stzfks=
+github.com/BeyondTrust/go-client-library-passwordsafe v0.14.2 h1:94hyZ3qHI9ehM+ZRCPAQgbQPzY7Tk6po+OvCaS+rmFs=
+github.com/BeyondTrust/go-client-library-passwordsafe v0.14.2/go.mod h1:72FMrpiz1fUSiIIIAXiCzQ55Y83spsu2jl5n/Stzfks=
 github.com/agext/levenshtein v1.2.2 h1:0S/Yg6LYmFJ5stwQeRp6EeOcCbj7xiqQSdNelsXvaqE=
 github.com/agext/levenshtein v1.2.2/go.mod h1:JEDfjyjHDjOF/1e4FlBE/PkbqA9OfWu2ki2W0IB5558=
 github.com/apparentlymart/go-textseg/v12 v12.0.0/go.mod h1:S/4uRK2UtaQttw1GenVJEynmyUenKwP++x/+DdGV/Ec=


### PR DESCRIPTION
### Purpose of the PR
Check why Spanish error message is being showed in terraform provider.

### According to ticket
<!-- Jira url or ticket number -->
https://beyondtrust.atlassian.net/browse/BIPS-24856.

### Summary of changes:
fix wrong spanish error message in validator.
