### PR TITLE
feat: Add creating Workgroups feature in terraform provider

### DIFF
--- a/go.mod
+++ b/go.mod
@@ -43,7 +43,7 @@ require (
 )
 
 require (
-	github.com/BeyondTrust/go-client-library-passwordsafe v0.14.3
+	github.com/BeyondTrust/go-client-library-passwordsafe v0.15.0
 	github.com/agext/levenshtein v1.2.2 // indirect
 	github.com/apparentlymart/go-textseg/v15 v15.0.0 // indirect
 	github.com/fatih/color v1.16.0 // indirect

--- a/go.sum
+++ b/go.sum
@@ -1,7 +1,7 @@
 dario.cat/mergo v1.0.0 h1:AGCNq9Evsj31mOgNPcLyXc+4PNABt905YmuqPYYpBWk=
 dario.cat/mergo v1.0.0/go.mod h1:uNxQE+84aUszobStD9th8a29P2fMDhsBdgRYvZOxGmk=
-github.com/BeyondTrust/go-client-library-passwordsafe v0.14.3 h1:KtmaJisSvfbtvogoaeq2JF+rj5IW0Qck2evEgL56G/M=
-github.com/BeyondTrust/go-client-library-passwordsafe v0.14.3/go.mod h1:72FMrpiz1fUSiIIIAXiCzQ55Y83spsu2jl5n/Stzfks=
+github.com/BeyondTrust/go-client-library-passwordsafe v0.15.0 h1:em9Ksqa+pZgdKyHQ1BlTMqYmQBXnE32u156X5HSELtc=
+github.com/BeyondTrust/go-client-library-passwordsafe v0.15.0/go.mod h1:on49hOdisiIBZ00S7SBszG1r8CHvr2jkv/qEwDJbHIM=
 github.com/Microsoft/go-winio v0.6.1 h1:9/kr64B9VUZrLm5YYwbGtUJnMgqWVOdUAXu6Migciow=
 github.com/Microsoft/go-winio v0.6.1/go.mod h1:LRdKpFKfdobln8UmuiYcKPot9D2v6svN5+sAH+4kjUM=
 github.com/ProtonMail/go-crypto v1.1.0-alpha.2 h1:bkyFVUP+ROOARdgCiJzNQo2V2kiB97LyUpzH9P6Hrlg=

--- a/main.go
+++ b/main.go
@@ -17,7 +17,6 @@ import (
 func main() {
 	ctx := context.Background()
 	providers := []func() tfprotov5.ProviderServer{
-
 		// terraform-plugin-framework provider (ephemeral resoruces), new provider
 		providerserver.NewProtocol5(
 			providerFramework.NewProvider(),

--- a/providers/constants/constants.go
+++ b/providers/constants/constants.go
@@ -4,7 +4,7 @@ package constants
 
 const (
 	APIPath          = "/BeyondTrust/api/public/v3"
-	FakeApiUrl       = "https://localhost:8080" + APIPath
+	FakeApiUrl       = "https://fakeurl:8080" + APIPath
 	FakeClientId     = "faked050-e266-4b05-9ced-35e7dd5093ae"
 	FakeClientSecret = "fake3BMkkxe4OpdsJPMhmYTRSpeHJYA/NVmcnmPZv5s="
 )

--- a/providers/constants/constants.go
+++ b/providers/constants/constants.go
@@ -1,0 +1,10 @@
+// Copyright 2025 BeyondTrust. All rights reserved.
+// Package constants.
+package constants
+
+const (
+	APIPath          = "/BeyondTrust/api/public/v3"
+	FakeApiUrl       = "https://localhost:8080" + APIPath
+	FakeClientId     = "faked050-e266-4b05-9ced-35e7dd5093ae"
+	FakeClientSecret = "fake3BMkkxe4OpdsJPMhmYTRSpeHJYA/NVmcnmPZv5s="
+)

--- a/providers/entities/entities.go
+++ b/providers/entities/entities.go
@@ -1,0 +1,16 @@
+// Copyright 2025 BeyondTrust. All rights reserved.
+// Package entities
+package entities
+
+type PasswordSafeTestConfig struct {
+	APIKey                       string
+	ClientID                     string
+	ClientSecret                 string
+	URL                          string
+	APIAccountName               string
+	ClientCertificatesFolderPath string
+	ClientCertificateName        string
+	ClientCertificatePassword    string
+	APIVersion                   string
+	Resource                     string
+}

--- a/providers/provider_framework/managed_account_ephemeral_test.go
+++ b/providers/provider_framework/managed_account_ephemeral_test.go
@@ -1,7 +1,6 @@
 package provider_framework
 
 import (
-	"fmt"
 	"net/http"
 	"net/http/httptest"
 	"regexp"
@@ -29,7 +28,7 @@ var ManganedAccountEphemeralOauthConfig entities.PasswordSafeTestConfig = entiti
 	ClientCertificateName:        "",
 	ClientCertificatePassword:    "",
 	APIVersion:                   "3.1",
-	Resource: fmt.Sprintf(`
+	Resource: `
 	ephemeral "passwordsafe_managed_acccount_ephemeral" "test" {
 	system_name = "server01"
 	account_name = "managed_account_01"
@@ -39,7 +38,7 @@ var ManganedAccountEphemeralOauthConfig entities.PasswordSafeTestConfig = entiti
 	data = ephemeral.passwordsafe_managed_acccount_ephemeral.test
 	}
 
-	resource "echo" "test" {}`),
+	resource "echo" "test" {}`,
 }
 
 func TestEphemeralManagedAcount(t *testing.T) {

--- a/providers/provider_framework/secrets_ephemeral_test.go
+++ b/providers/provider_framework/secrets_ephemeral_test.go
@@ -1,7 +1,6 @@
 package provider_framework
 
 import (
-	"fmt"
 	"net/http"
 	"net/http/httptest"
 	"regexp"
@@ -29,7 +28,7 @@ var SecretEphemeralOauthConfig entities.PasswordSafeTestConfig = entities.Passwo
 	ClientCertificateName:        "",
 	ClientCertificatePassword:    "",
 	APIVersion:                   "3.1",
-	Resource: fmt.Sprintf(`
+	Resource: `
 	ephemeral "passwordsafe_secret_ephemeral" "test" {
 	title = "secret_title"
 	path = "secret_path"
@@ -40,7 +39,7 @@ var SecretEphemeralOauthConfig entities.PasswordSafeTestConfig = entities.Passwo
 	data = ephemeral.passwordsafe_secret_ephemeral.test
 	}
 
-	resource "echo" "test" {}`),
+	resource "echo" "test" {}`,
 }
 
 func TestEphemeralSecret(t *testing.T) {
@@ -90,7 +89,7 @@ func TestEphemeralSecret(t *testing.T) {
 		ClientCertificateName:        "",
 		ClientCertificatePassword:    "",
 		APIVersion:                   "3.1",
-		Resource: fmt.Sprintf(`
+		Resource: `
 		ephemeral "passwordsafe_secret_ephemeral" "test" {
 		title = "secret_title"
 		path = "secret_path"
@@ -101,7 +100,7 @@ func TestEphemeralSecret(t *testing.T) {
 		data = ephemeral.passwordsafe_secret_ephemeral.test
 		}
 
-		resource "echo" "test" {}`),
+		resource "echo" "test" {}`,
 	}
 
 	APIKeyConfig.URL = server.URL

--- a/providers/provider_framework/secrets_ephemeral_test.go
+++ b/providers/provider_framework/secrets_ephemeral_test.go
@@ -1,10 +1,13 @@
-package providerv2
+package provider_framework
 
 import (
 	"fmt"
 	"net/http"
 	"net/http/httptest"
-	"net/url"
+	"regexp"
+	"terraform-provider-passwordsafe/providers/constants"
+	"terraform-provider-passwordsafe/providers/entities"
+	"terraform-provider-passwordsafe/providers/utils"
 	"testing"
 
 	"github.com/hashicorp/terraform-plugin-framework/providerserver"
@@ -17,42 +20,93 @@ import (
 	"github.com/hashicorp/terraform-plugin-testing/tfversion"
 )
 
+var SecretEphemeralOauthConfig entities.PasswordSafeTestConfig = entities.PasswordSafeTestConfig{
+	ClientID:                     constants.FakeClientId,
+	ClientSecret:                 constants.FakeClientSecret,
+	URL:                          "",
+	APIAccountName:               "",
+	ClientCertificatesFolderPath: "",
+	ClientCertificateName:        "",
+	ClientCertificatePassword:    "",
+	APIVersion:                   "3.1",
+	Resource: fmt.Sprintf(`
+	ephemeral "passwordsafe_secret_ephemeral" "test" {
+	title = "secret_title"
+	path = "secret_path"
+	separator = "/"
+	}
+
+	provider "echo" {
+	data = ephemeral.passwordsafe_secret_ephemeral.test
+	}
+
+	resource "echo" "test" {}`),
+}
+
 func TestEphemeralSecret(t *testing.T) {
 
 	// mocking Password Safe API
-	server := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+	server := httptest.NewTLSServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
 
 		// mocking Response according to the endpoint path
 		switch r.URL.Path {
-		case "/Auth/connect/token":
+		case constants.APIPath + "/Auth/connect/token":
 			_, err := w.Write([]byte(`{"access_token": "fake_token", "expires_in": 600, "token_type": "Bearer", "scope": "publicapi"}`))
 			if err != nil {
-				t.Error("Test case Failed")
+				t.Error(err.Error())
 			}
 
-		case "/Auth/SignAppIn":
+		case constants.APIPath + "/Auth/SignAppIn":
 			_, err := w.Write([]byte(`{"UserId":1, "EmailAddress":"test@beyondtrust.com"}`))
 
 			if err != nil {
-				t.Error("Test case Failed")
+				t.Error(err.Error())
 			}
 
-		case "/secrets-safe/secrets":
+		case constants.APIPath + "/secrets-safe/secrets":
 			_, err := w.Write([]byte(`[{"SecretType": "SECRET", "Password": "fake_password_a#$%!","Id": "9152f5b6-07d6-4955-175a-08db047219ce","Title": "credential_in_sub_3"}]`))
 			if err != nil {
-				t.Error("Test case Failed")
+				t.Error(err.Error())
 			}
 
-		case "/Auth/Signout":
+		case constants.APIPath + "/Auth/Signout":
 			_, err := w.Write([]byte(``))
 			if err != nil {
-				t.Error("Test case Failed")
+				t.Error(err.Error())
 			}
 		}
 
 	}))
 
-	serverURL, _ := url.Parse(server.URL + "/")
+	server.URL = server.URL + constants.APIPath
+
+	APIKeyConfig := entities.PasswordSafeTestConfig{
+		APIKey:                       "fake_api_key_82a8a8e48b488d",
+		ClientID:                     "",
+		ClientSecret:                 "",
+		URL:                          "",
+		APIAccountName:               "api_key_username",
+		ClientCertificatesFolderPath: "",
+		ClientCertificateName:        "",
+		ClientCertificatePassword:    "",
+		APIVersion:                   "3.1",
+		Resource: fmt.Sprintf(`
+		ephemeral "passwordsafe_secret_ephemeral" "test" {
+		title = "secret_title"
+		path = "secret_path"
+		separator = "/"
+		}
+
+		provider "echo" {
+		data = ephemeral.passwordsafe_secret_ephemeral.test
+		}
+
+		resource "echo" "test" {}`),
+	}
+
+	APIKeyConfig.URL = server.URL
+
+	SecretEphemeralOauthConfig.URL = server.URL
 
 	resource.Test(t, resource.TestCase{
 
@@ -68,7 +122,7 @@ func TestEphemeralSecret(t *testing.T) {
 		Steps: []resource.TestStep{
 			{
 				// test using aki key authentication
-				Config: testSecretEphemeralResourceUsingApiKey(serverURL.String()),
+				Config: utils.TestResourceConfig(APIKeyConfig),
 				ConfigStateChecks: []statecheck.StateCheck{
 					statecheck.ExpectKnownValue(
 						"echo.test",
@@ -79,7 +133,7 @@ func TestEphemeralSecret(t *testing.T) {
 			},
 			{
 				// test using oauth authentication
-				Config: testSecretEphemeralResourceUsingOauth(serverURL.String()),
+				Config: utils.TestResourceConfig(SecretEphemeralOauthConfig),
 				ConfigStateChecks: []statecheck.StateCheck{
 					statecheck.ExpectKnownValue(
 						"echo.test",
@@ -92,60 +146,61 @@ func TestEphemeralSecret(t *testing.T) {
 	})
 }
 
-func testSecretEphemeralResourceUsingApiKey(serverURL string) string {
-	return fmt.Sprintf(`
-		provider "passwordsafe" {
-			api_key = "fake_api_key_82a8a8e48b488d"
-			client_id = ""
-			client_secret = ""
-			url =  %[1]q
-			api_account_name = "apikey_user"
-			client_certificates_folder_path = ""
-			client_certificate_name = ""
-			client_certificate_password = ""
-			api_version = "3.1"
+func TestEphemeralSecretNotFound(t *testing.T) {
+
+	// mocking Password Safe API
+	server := httptest.NewTLSServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+
+		// mocking Response according to the endpoint path
+		switch r.URL.Path {
+		case constants.APIPath + "/Auth/connect/token":
+			_, err := w.Write([]byte(`{"access_token": "fake_token", "expires_in": 600, "token_type": "Bearer", "scope": "publicapi"}`))
+			if err != nil {
+				t.Error(err.Error())
+			}
+
+		case constants.APIPath + "/Auth/SignAppIn":
+			_, err := w.Write([]byte(`{"UserId":1, "EmailAddress":"test@beyondtrust.com"}`))
+
+			if err != nil {
+				t.Error(err.Error())
+			}
+
+		case constants.APIPath + "/secrets-safe/secrets":
+			_, err := w.Write([]byte(`[]`))
+			if err != nil {
+				t.Error(err.Error())
+			}
+
+		case constants.APIPath + "/Auth/Signout":
+			_, err := w.Write([]byte(``))
+			if err != nil {
+				t.Error(err.Error())
+			}
 		}
 
-		ephemeral "passwordsafe_secret_ephemeral" "test" {
-		title = "secret_title"
-		path = "secret_path"
-		separator = "/"
-		}
+	}))
 
-		provider "echo" {
-		data = ephemeral.passwordsafe_secret_ephemeral.test
-		}
+	server.URL = server.URL + constants.APIPath
 
-		resource "echo" "test" {}
+	SecretEphemeralOauthConfig.URL = server.URL
 
-		`, serverURL)
-}
+	resource.Test(t, resource.TestCase{
 
-func testSecretEphemeralResourceUsingOauth(serverURL string) string {
-	return fmt.Sprintf(`
-		provider "passwordsafe" {
-			api_key = ""
-			client_id = "fake_client_id_35e7dd5093ae"
-			client_secret = "fake_cliente_secret_JPMhmYTRSpeHJY"
-			url =  %[1]q
-			api_account_name = ""
-			client_certificates_folder_path = ""
-			client_certificate_name = ""
-			client_certificate_password = ""
-			api_version = "3.1"
-		}
-
-		ephemeral "passwordsafe_secret_ephemeral" "test" {
-		title = "secret_title"
-		path = "secret_path"
-		separator = "/"
-		}
-
-		provider "echo" {
-		data = ephemeral.passwordsafe_secret_ephemeral.test
-		}
-
-		resource "echo" "test" {}
-
-	`, serverURL)
+		TerraformVersionChecks: []tfversion.TerraformVersionCheck{
+			tfversion.SkipBelow(tfversion.Version1_10_0),
+		},
+		PreCheck: func() {},
+		ProtoV6ProviderFactories: map[string]func() (tfprotov6.ProviderServer, error){
+			"passwordsafe": providerserver.NewProtocol6WithError(NewProvider()),
+			"echo":         echoprovider.NewProviderServer(),
+		},
+		Steps: []resource.TestStep{
+			{
+				// test using oauth authentication
+				Config:      utils.TestResourceConfig(SecretEphemeralOauthConfig),
+				ExpectError: regexp.MustCompile("error SecretGetSecretByPath, Secret was not found: StatusCode: 404"),
+			},
+		},
+	})
 }

--- a/providers/provider_framework/workgroups_resource.go
+++ b/providers/provider_framework/workgroups_resource.go
@@ -1,0 +1,138 @@
+// Copyright 2025 BeyondTrust. All rights reserved.
+// Package provider_framework implements a terraform provider that can talk with Beyondtrust Secret Safe API.
+package provider_framework
+
+import (
+	"context"
+	"terraform-provider-passwordsafe/providers/utils"
+
+	"github.com/BeyondTrust/go-client-library-passwordsafe/api/entities"
+	"github.com/BeyondTrust/go-client-library-passwordsafe/api/workgroups"
+	"github.com/hashicorp/terraform-plugin-framework/path"
+	"github.com/hashicorp/terraform-plugin-framework/resource"
+	"github.com/hashicorp/terraform-plugin-framework/resource/schema"
+	"github.com/hashicorp/terraform-plugin-framework/types"
+)
+
+var _ resource.Resource = &WorkGroupResource{}
+var _ resource.ResourceWithImportState = &WorkGroupResource{}
+
+func NewWorkGroupResource() resource.Resource {
+	return &WorkGroupResource{}
+}
+
+type WorkGroupResource struct {
+	providerInfo *ProviderData
+}
+
+type WorkGroupResorceModel struct {
+	Name           types.String `tfsdk:"name"`
+	OrganizationID types.String `tfsdk:"organization_id"`
+	Id             types.Int32  `tfsdk:"id"`
+}
+
+func (r *WorkGroupResource) Metadata(ctx context.Context, req resource.MetadataRequest, resp *resource.MetadataResponse) {
+	resp.TypeName = req.ProviderTypeName + "_workgroup"
+
+}
+
+func (r *WorkGroupResource) Schema(ctx context.Context, req resource.SchemaRequest, resp *resource.SchemaResponse) {
+	resp.Schema = schema.Schema{
+		MarkdownDescription: "Workgroup resource",
+
+		Attributes: map[string]schema.Attribute{
+			"name": schema.StringAttribute{
+				MarkdownDescription: "Workgroup Name",
+				Required:            true,
+			},
+			"organization_id": schema.StringAttribute{
+				MarkdownDescription: "Organization Id",
+				Optional:            true,
+				Computed:            false,
+			},
+			"id": schema.Int32Attribute{
+				MarkdownDescription: "Workgroup Id",
+				Optional:            true,
+				Computed:            true,
+			},
+		},
+	}
+}
+
+func (r *WorkGroupResource) Configure(ctx context.Context, req resource.ConfigureRequest, resp *resource.ConfigureResponse) {
+
+	// getting data from Provider
+	c, _ := req.ProviderData.(ProviderData)
+
+	r.providerInfo = &c
+
+	if r.providerInfo.userName == "" {
+		return
+	}
+
+}
+
+func (r *WorkGroupResource) Create(ctx context.Context, req resource.CreateRequest, resp *resource.CreateResponse) {
+
+	var data WorkGroupResorceModel
+
+	resp.Diagnostics.Append(req.Plan.Get(ctx, &data)...)
+
+	if resp.Diagnostics.HasError() {
+		return
+	}
+
+	_, err := utils.Autenticate(*r.providerInfo.authenticationObj, &mu, &signInCount, zapLogger)
+	if err != nil {
+		resp.Diagnostics.AddError("Error getting Authentication", err.Error())
+		return
+	}
+
+	workgroups.NewWorkGroupObj(*r.providerInfo.authenticationObj, nil)
+
+	// instantiating workgroup obj
+	workGroupObj, _ := workgroups.NewWorkGroupObj(*r.providerInfo.authenticationObj, zapLogger)
+
+	workGroupDetails := entities.WorkGroupDetails{
+		Name:           data.Name.ValueString(),
+		OrganizationID: data.OrganizationID.ValueString(),
+	}
+
+	// creating a workgroup.
+	createdWorkGroup, err := workGroupObj.CreateWorkGroupFlow(workGroupDetails)
+
+	if err != nil {
+		resp.Diagnostics.AddError("Error creating workgroup", err.Error())
+		return
+	}
+
+	if createdWorkGroup.OrganizationID == "" {
+		data.OrganizationID = types.StringValue(createdWorkGroup.OrganizationID)
+	}
+
+	data.Id = types.Int32Value(int32(createdWorkGroup.ID))
+
+	err = utils.SignOut(*r.providerInfo.authenticationObj, &muOut, &signInCount, zapLogger)
+	if err != nil {
+		resp.Diagnostics.AddError("Error Signing Out", err.Error())
+		return
+	}
+
+	resp.Diagnostics.Append(resp.State.Set(ctx, &data)...)
+}
+
+func (r *WorkGroupResource) Read(ctx context.Context, req resource.ReadRequest, resp *resource.ReadResponse) {
+	// method not implemented
+}
+
+func (r *WorkGroupResource) Update(ctx context.Context, req resource.UpdateRequest, resp *resource.UpdateResponse) {
+	// method not implemented
+}
+
+func (r *WorkGroupResource) Delete(ctx context.Context, req resource.DeleteRequest, resp *resource.DeleteResponse) {
+	// method not implemented
+}
+
+func (r *WorkGroupResource) ImportState(ctx context.Context, req resource.ImportStateRequest, resp *resource.ImportStateResponse) {
+	resource.ImportStatePassthroughID(ctx, path.Root("id"), req, resp)
+}

--- a/providers/provider_framework/workgroups_resource.go
+++ b/providers/provider_framework/workgroups_resource.go
@@ -88,10 +88,13 @@ func (r *WorkGroupResource) Create(ctx context.Context, req resource.CreateReque
 		return
 	}
 
-	workgroups.NewWorkGroupObj(*r.providerInfo.authenticationObj, nil)
-
 	// instantiating workgroup obj
-	workGroupObj, _ := workgroups.NewWorkGroupObj(*r.providerInfo.authenticationObj, zapLogger)
+	workGroupObj, err := workgroups.NewWorkGroupObj(*r.providerInfo.authenticationObj, zapLogger)
+
+	if err != nil {
+		resp.Diagnostics.AddError("Error creating authentication object", err.Error())
+		return
+	}
 
 	workGroupDetails := entities.WorkGroupDetails{
 		Name:           data.Name.ValueString(),

--- a/providers/provider_framework/workgroups_resources_test.go
+++ b/providers/provider_framework/workgroups_resources_test.go
@@ -1,7 +1,6 @@
 package provider_framework
 
 import (
-	"fmt"
 	"net/http"
 	"net/http/httptest"
 	"regexp"
@@ -64,10 +63,10 @@ func TestCreateWorkgroup(t *testing.T) {
 		ClientCertificateName:        "",
 		ClientCertificatePassword:    "",
 		APIVersion:                   "3.1",
-		Resource: fmt.Sprintf(`
+		Resource: `
 		resource "passwordsafe_workgroup" "workgroup" {
  			name = "test"
-		}`),
+		}`,
 	}
 
 	server.URL = server.URL + constants.APIPath
@@ -113,10 +112,10 @@ func TestCreateWorkgroupBadAPIVersion(t *testing.T) {
 		ClientCertificateName:        "",
 		ClientCertificatePassword:    "",
 		APIVersion:                   "3.111",
-		Resource: fmt.Sprintf(`
+		Resource: `
 		resource "passwordsafe_workgroup" "workgroup" {
  			name = "test"
-		}`),
+		}`,
 	}
 
 	resource.Test(t, resource.TestCase{
@@ -150,10 +149,10 @@ func TestCreateWorkgroupBadCredentials(t *testing.T) {
 		ClientCertificateName:        "",
 		ClientCertificatePassword:    "",
 		APIVersion:                   "3.1",
-		Resource: fmt.Sprintf(`
+		Resource: `
 		resource "passwordsafe_workgroup" "workgroup" {
  			name = "test"
-		}`),
+		}`,
 	}
 
 	resource.Test(t, resource.TestCase{

--- a/providers/provider_framework/workgroups_resources_test.go
+++ b/providers/provider_framework/workgroups_resources_test.go
@@ -1,0 +1,252 @@
+package provider_framework
+
+import (
+	"fmt"
+	"net/http"
+	"net/http/httptest"
+	"regexp"
+	"terraform-provider-passwordsafe/providers/constants"
+	"terraform-provider-passwordsafe/providers/entities"
+	"terraform-provider-passwordsafe/providers/utils"
+	"testing"
+
+	"github.com/hashicorp/terraform-plugin-framework/providerserver"
+	"github.com/hashicorp/terraform-plugin-go/tfprotov6"
+	"github.com/hashicorp/terraform-plugin-testing/echoprovider"
+	"github.com/hashicorp/terraform-plugin-testing/helper/resource"
+	"github.com/hashicorp/terraform-plugin-testing/knownvalue"
+	"github.com/hashicorp/terraform-plugin-testing/statecheck"
+	"github.com/hashicorp/terraform-plugin-testing/tfjsonpath"
+	"github.com/hashicorp/terraform-plugin-testing/tfversion"
+)
+
+func TestCreateWorkgroup(t *testing.T) {
+
+	// mocking Password Safe API
+	server := httptest.NewTLSServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+
+		// mocking Response according to the endpoint path
+		switch r.URL.Path {
+		case constants.APIPath + "/Auth/connect/token":
+			_, err := w.Write([]byte(`{"access_token": "fake_token", "expires_in": 600, "token_type": "Bearer", "scope": "publicapi"}`))
+			if err != nil {
+				t.Error(err.Error())
+			}
+
+		case constants.APIPath + "/Auth/SignAppIn":
+			_, err := w.Write([]byte(`{"UserId":1, "EmailAddress":"test@beyondtrust.com"}`))
+
+			if err != nil {
+				t.Error(err.Error())
+			}
+
+		case constants.APIPath + "/Workgroups":
+			_, err := w.Write([]byte(`{"OrganizationID": "abcd27cf-791a-4c65-abe9-a6a250b8e4f6", "ID": 29, "Name": "Test 2025 10"}`))
+			if err != nil {
+				t.Error(err.Error())
+			}
+
+		case constants.APIPath + "/Auth/Signout":
+			_, err := w.Write([]byte(``))
+			if err != nil {
+				t.Error(err.Error())
+			}
+		}
+
+	}))
+
+	config := entities.PasswordSafeTestConfig{
+		APIKey:                       "",
+		ClientID:                     constants.FakeClientId,
+		ClientSecret:                 constants.FakeClientSecret,
+		APIAccountName:               "",
+		ClientCertificatesFolderPath: "",
+		ClientCertificateName:        "",
+		ClientCertificatePassword:    "",
+		APIVersion:                   "3.1",
+		Resource: fmt.Sprintf(`
+		resource "passwordsafe_workgroup" "workgroup" {
+ 			name = "test"
+		}`),
+	}
+
+	server.URL = server.URL + constants.APIPath
+
+	config.URL = server.URL
+
+	resource.Test(t, resource.TestCase{
+
+		TerraformVersionChecks: []tfversion.TerraformVersionCheck{
+			tfversion.SkipBelow(tfversion.Version1_10_0),
+		},
+		PreCheck: func() {},
+		// load providers, echo is just for test purposes
+		ProtoV6ProviderFactories: map[string]func() (tfprotov6.ProviderServer, error){
+			"passwordsafe": providerserver.NewProtocol6WithError(NewProvider()),
+			"echo":         echoprovider.NewProviderServer(),
+		},
+		Steps: []resource.TestStep{
+			{
+				// test using oauth authentication
+				Config: utils.TestResourceConfig(config),
+				ConfigStateChecks: []statecheck.StateCheck{
+					statecheck.ExpectKnownValue(
+						"passwordsafe_workgroup.workgroup",
+						tfjsonpath.New("id"),
+						knownvalue.Int32Exact(29),
+					),
+				},
+			},
+		},
+	})
+}
+
+func TestCreateWorkgroupBadAPIVersion(t *testing.T) {
+
+	config := entities.PasswordSafeTestConfig{
+		APIKey:                       "",
+		ClientID:                     constants.FakeClientId,
+		ClientSecret:                 constants.FakeClientSecret,
+		URL:                          constants.FakeApiUrl,
+		APIAccountName:               "",
+		ClientCertificatesFolderPath: "",
+		ClientCertificateName:        "",
+		ClientCertificatePassword:    "",
+		APIVersion:                   "3.111",
+		Resource: fmt.Sprintf(`
+		resource "passwordsafe_workgroup" "workgroup" {
+ 			name = "test"
+		}`),
+	}
+
+	resource.Test(t, resource.TestCase{
+
+		TerraformVersionChecks: []tfversion.TerraformVersionCheck{
+			tfversion.SkipBelow(tfversion.Version1_10_0),
+		},
+		PreCheck: func() {},
+		ProtoV6ProviderFactories: map[string]func() (tfprotov6.ProviderServer, error){
+			"passwordsafe": providerserver.NewProtocol6WithError(NewProvider()),
+		},
+		Steps: []resource.TestStep{
+			{
+				// test using oauth authentication
+				Config:      utils.TestResourceConfig(config),
+				ExpectError: regexp.MustCompile("Max length '3' for 'ApiVersion' field."),
+			},
+		},
+	})
+}
+
+func TestCreateWorkgroupBadCredentials(t *testing.T) {
+
+	config := entities.PasswordSafeTestConfig{
+		APIKey:                       "",
+		ClientID:                     "",
+		ClientSecret:                 "",
+		URL:                          constants.FakeApiUrl,
+		APIAccountName:               "",
+		ClientCertificatesFolderPath: "",
+		ClientCertificateName:        "",
+		ClientCertificatePassword:    "",
+		APIVersion:                   "3.1",
+		Resource: fmt.Sprintf(`
+		resource "passwordsafe_workgroup" "workgroup" {
+ 			name = "test"
+		}`),
+	}
+
+	resource.Test(t, resource.TestCase{
+
+		TerraformVersionChecks: []tfversion.TerraformVersionCheck{
+			tfversion.SkipBelow(tfversion.Version1_10_0),
+		},
+		PreCheck: func() {},
+		ProtoV6ProviderFactories: map[string]func() (tfprotov6.ProviderServer, error){
+			"passwordsafe": providerserver.NewProtocol6WithError(NewProvider()),
+		},
+		Steps: []resource.TestStep{
+			{
+				// test using oauth authentication
+				Config:      utils.TestResourceConfig(config),
+				ExpectError: regexp.MustCompile("Please add a valid credential"),
+			},
+		},
+	})
+}
+
+/*
+func TestCreateWorkgroupErrorInSignOut(t *testing.T) {
+
+	// mocking Password Safe API
+	server := httptest.NewTLSServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+
+		// mocking Response according to the endpoint path
+		switch r.URL.Path {
+		case constants.APIPath + "/Auth/connect/token":
+			_, err := w.Write([]byte(`{"access_token": "fake_token", "expires_in": 600, "token_type": "Bearer", "scope": "publicapi"}`))
+			if err != nil {
+				t.Error(err.Error())
+			}
+
+		case constants.APIPath + "/Auth/SignAppIn":
+			_, err := w.Write([]byte(`{"UserId":1, "EmailAddress":"test@beyondtrust.com"}`))
+
+			if err != nil {
+				t.Error(err.Error())
+			}
+
+		case constants.APIPath + "/Workgroups":
+			_, err := w.Write([]byte(`{"OrganizationID": "abcd27cf-791a-4c65-abe9-a6a250b8e4f6", "ID": 29, "Name": "Test 2025 10"}`))
+			if err != nil {
+				t.Error(err.Error())
+			}
+
+		case constants.APIPath + "/Auth/Signout":
+			w.WriteHeader(http.StatusNotFound)
+			_, err := w.Write([]byte(``))
+			if err != nil {
+				t.Error(err.Error())
+			}
+		}
+
+	}))
+
+	config := entities.PasswordSafeTestConfig{
+		APIKey:                       "",
+		ClientID:                     constants.FakeClientId,
+		ClientSecret:                 constants.FakeClientSecret,
+		APIAccountName:               "",
+		ClientCertificatesFolderPath: "",
+		ClientCertificateName:        "",
+		ClientCertificatePassword:    "",
+		APIVersion:                   "3.1",
+		Resource: fmt.Sprintf(`
+		resource "passwordsafe_workgroup" "workgroup" {
+ 			name = "test"
+		}`),
+	}
+
+	server.URL = server.URL + constants.APIPath
+
+	config.URL = server.URL
+
+	resource.Test(t, resource.TestCase{
+
+		TerraformVersionChecks: []tfversion.TerraformVersionCheck{
+			tfversion.SkipBelow(tfversion.Version1_10_0),
+		},
+		PreCheck: func() {},
+		ProtoV6ProviderFactories: map[string]func() (tfprotov6.ProviderServer, error){
+			"passwordsafe": providerserver.NewProtocol6WithError(NewProvider()),
+		},
+		Steps: []resource.TestStep{
+			{
+				// test using oauth authentication
+				Config:      utils.TestResourceConfig(config),
+				ExpectError: regexp.MustCompile("Error Signing Out"),
+			},
+		},
+	})
+}
+*/

--- a/providers/provider_sdkv2/common.go
+++ b/providers/provider_sdkv2/common.go
@@ -3,8 +3,7 @@
 package provider
 
 import (
-	"fmt"
-	"sync/atomic"
+	"terraform-provider-passwordsafe/providers/utils"
 
 	auth "github.com/BeyondTrust/go-client-library-passwordsafe/api/authentication"
 	"github.com/BeyondTrust/go-client-library-passwordsafe/api/entities"
@@ -15,23 +14,12 @@ import (
 func autenticate(d *schema.ResourceData, m interface{}) (entities.SignApinResponse, error) {
 	authenticationObj := m.(*auth.AuthenticationObj)
 	var err error
+	var signApinResponse entities.SignApinResponse
 
-	mu.Lock()
-	if atomic.LoadUint64(&signInCount) > 0 {
-		atomic.AddUint64(&signInCount, 1)
-		zapLogger.Debug(fmt.Sprintf("%v %v", "Already signed in", atomic.LoadUint64(&signInCount)))
-		mu.Unlock()
-
-	} else {
-		signApinResponse, err = authenticationObj.GetPasswordSafeAuthentication()
-		if err != nil {
-			mu.Unlock()
-			zapLogger.Error(err.Error())
-			return entities.SignApinResponse{}, err
-		}
-		atomic.AddUint64(&signInCount, 1)
-		zapLogger.Debug(fmt.Sprintf("%v %v", "signin", atomic.LoadUint64(&signInCount)))
-		mu.Unlock()
+	signApinResponse, err = utils.Autenticate(*authenticationObj, &mu, &signInCount, zapLogger)
+	if err != nil {
+		zapLogger.Error(err.Error())
+		return signApinResponse, err
 	}
 
 	return signApinResponse, nil
@@ -42,25 +30,14 @@ func signOut(d *schema.ResourceData, m interface{}) error {
 	authenticationObj := m.(*auth.AuthenticationObj)
 	var err error
 
-	mu_out.Lock()
-	if atomic.LoadUint64(&signInCount) > 1 {
-		zapLogger.Debug(fmt.Sprintf("%v %v", "Ignore signout", atomic.LoadUint64(&signInCount)))
-		// decrement counter, don't signout.
-		atomic.AddUint64(&signInCount, ^uint64(0))
-		mu_out.Unlock()
-	} else {
-		err = authenticationObj.SignOut()
-		if err != nil {
-			return err
-		}
-		zapLogger.Debug(fmt.Sprintf("%v %v", "signout user", atomic.LoadUint64(&signInCount)))
-		// decrement counter
-		atomic.AddUint64(&signInCount, ^uint64(0))
-		mu_out.Unlock()
-
+	err = utils.SignOut(*authenticationObj, &muOut, &signInCount, zapLogger)
+	if err != nil {
+		zapLogger.Error(err.Error())
+		return err
 	}
 
 	return nil
+
 }
 
 // getOwnersSchema get Owners schema.

--- a/providers/provider_sdkv2/common.go
+++ b/providers/provider_sdkv2/common.go
@@ -28,9 +28,8 @@ func autenticate(d *schema.ResourceData, m interface{}) (entities.SignApinRespon
 // signOut sign Password Safe out
 func signOut(d *schema.ResourceData, m interface{}) error {
 	authenticationObj := m.(*auth.AuthenticationObj)
-	var err error
 
-	err = utils.SignOut(*authenticationObj, &muOut, &signInCount, zapLogger)
+	err := utils.SignOut(*authenticationObj, &muOut, &signInCount, zapLogger)
 	if err != nil {
 		zapLogger.Error(err.Error())
 		return err

--- a/providers/provider_sdkv2/provider.go
+++ b/providers/provider_sdkv2/provider.go
@@ -22,7 +22,7 @@ import (
 
 var signInCount uint64
 var mu sync.Mutex
-var mu_out sync.Mutex
+var muOut sync.Mutex
 
 var signApinResponse entities.SignApinResponse
 
@@ -121,11 +121,11 @@ func Provider() *schema.Provider {
 func providerConfigure(ctx context.Context, d *schema.ResourceData) (interface{}, diag.Diagnostics) {
 
 	apikey := d.Get("api_key").(string)
-	client_id := d.Get("client_id").(string)
-	client_secret := d.Get("client_secret").(string)
+	clientId := d.Get("client_id").(string)
+	clientSecret := d.Get("client_secret").(string)
 	url := d.Get("url").(string)
 	apiVersion := d.Get("api_version").(string)
-	accountname := d.Get("api_account_name").(string)
+	accountName := d.Get("api_account_name").(string)
 	verifyca := d.Get("verify_ca").(bool)
 	clientCertificatePath := d.Get("client_certificates_folder_path").(string)
 	clientCertificateName := d.Get("client_certificate_name").(string)
@@ -133,11 +133,11 @@ func providerConfigure(ctx context.Context, d *schema.ResourceData) (interface{}
 
 	apikey = strings.TrimSpace(apikey)
 	url = strings.TrimSpace(url)
-	accountname = strings.TrimSpace(accountname)
+	accountName = strings.TrimSpace(accountName)
 
 	var diags diag.Diagnostics
 
-	if apikey == "" && client_id == "" && client_secret == "" {
+	if apikey == "" && clientId == "" && clientSecret == "" {
 		diags = append(diags, diag.Diagnostic{
 			Severity: diag.Error,
 			Summary:  "Invalid Authentication method",
@@ -155,7 +155,7 @@ func providerConfigure(ctx context.Context, d *schema.ResourceData) (interface{}
 		return nil, diags
 	}
 
-	if apikey != "" && accountname == "" {
+	if apikey != "" && accountName == "" {
 		diags = append(diags, diag.Diagnostic{
 			Severity: diag.Error,
 			Summary:  "Invalid Account Name",
@@ -165,6 +165,7 @@ func providerConfigure(ctx context.Context, d *schema.ResourceData) (interface{}
 	}
 
 	retryMaxElapsedTimeMinutes := 2
+	clientTimeOutInSeconds := 30
 
 	backoffDefinition := backoff.NewExponentialBackOff()
 	backoffDefinition.InitialInterval = 1 * time.Second
@@ -182,6 +183,27 @@ func providerConfigure(ctx context.Context, d *schema.ResourceData) (interface{}
 		}
 	}
 
+	// Create an instance of ValidationParams
+	params := utils.ValidationParams{
+		ClientID:                   clientId,
+		ClientSecret:               clientSecret,
+		ApiUrl:                     &url,
+		ApiVersion:                 apiVersion,
+		ClientTimeOutInSeconds:     clientTimeOutInSeconds,
+		VerifyCa:                   verifyca,
+		Logger:                     zapLogger,
+		Certificate:                certificate,
+		CertificateKey:             certificateKey,
+		RetryMaxElapsedTimeMinutes: &retryMaxElapsedTimeMinutes,
+	}
+
+	// validate inputs
+	errorsInInputs := utils.ValidateInputs(params)
+
+	if errorsInInputs != nil {
+		return nil, diag.FromErr(err)
+	}
+
 	httpClientObj, err := utils.GetHttpClient(45, verifyca, certificate, certificateKey, zapLogger)
 	if err != nil {
 		return nil, diag.FromErr(err)
@@ -197,7 +219,7 @@ func providerConfigure(ctx context.Context, d *schema.ResourceData) (interface{}
 			APIVersion:                 apiVersion,
 			ClientID:                   "",
 			ClientSecret:               "",
-			ApiKey:                     fmt.Sprintf("%v;runas=%v;", apikey, accountname),
+			ApiKey:                     fmt.Sprintf("%v;runas=%v;", apikey, accountName),
 			Logger:                     zapLogger,
 			RetryMaxElapsedTimeSeconds: retryMaxElapsedTimeMinutes,
 		}
@@ -213,8 +235,8 @@ func providerConfigure(ctx context.Context, d *schema.ResourceData) (interface{}
 		BackoffDefinition:          backoffDefinition,
 		EndpointURL:                url,
 		APIVersion:                 apiVersion,
-		ClientID:                   client_id,
-		ClientSecret:               client_secret,
+		ClientID:                   clientId,
+		ClientSecret:               clientSecret,
 		ApiKey:                     "",
 		Logger:                     zapLogger,
 		RetryMaxElapsedTimeSeconds: retryMaxElapsedTimeMinutes,

--- a/providers/provider_sdkv2/provider.go
+++ b/providers/provider_sdkv2/provider.go
@@ -10,7 +10,6 @@ import (
 	"time"
 
 	auth "github.com/BeyondTrust/go-client-library-passwordsafe/api/authentication"
-	"github.com/BeyondTrust/go-client-library-passwordsafe/api/entities"
 	"github.com/BeyondTrust/go-client-library-passwordsafe/api/logging"
 	"github.com/BeyondTrust/go-client-library-passwordsafe/api/utils"
 	backoff "github.com/cenkalti/backoff/v4"
@@ -23,8 +22,6 @@ import (
 var signInCount uint64
 var mu sync.Mutex
 var muOut sync.Mutex
-
-var signApinResponse entities.SignApinResponse
 
 // Define the zap configuration
 var config = zap.Config{

--- a/providers/utils/methods.go
+++ b/providers/utils/methods.go
@@ -1,0 +1,95 @@
+// Copyright 2025 BeyondTrust. All rights reserved.
+// Package utils.
+package utils
+
+import (
+	"fmt"
+	"sync"
+	"sync/atomic"
+	"terraform-provider-passwordsafe/providers/entities"
+
+	auth "github.com/BeyondTrust/go-client-library-passwordsafe/api/authentication"
+	libraryEntitites "github.com/BeyondTrust/go-client-library-passwordsafe/api/entities"
+	"github.com/BeyondTrust/go-client-library-passwordsafe/api/logging"
+)
+
+func TestResourceConfig(config entities.PasswordSafeTestConfig) string {
+	return fmt.Sprintf(`
+		provider "passwordsafe" {
+			api_key = "%s"
+			client_id = "%s"
+			client_secret = "%s"
+			url = "%s"
+			verify_ca=false
+			api_account_name = "%s"
+			client_certificates_folder_path = "%s"
+			client_certificate_name = "%s"
+			client_certificate_password = "%s"
+			api_version = "%s"
+		}
+
+		%s`,
+
+		config.APIKey,
+		config.ClientID,
+		config.ClientSecret,
+		config.URL,
+		config.APIAccountName,
+		config.ClientCertificatesFolderPath,
+		config.ClientCertificateName,
+		config.ClientCertificatePassword,
+		config.APIVersion,
+		config.Resource,
+	)
+}
+
+// autenticate get Password Safe authentication.
+func Autenticate(authenticationObj auth.AuthenticationObj, mu *sync.Mutex, signInCount *uint64, zapLogger logging.Logger) (libraryEntitites.SignApinResponse, error) {
+	var err error
+	var signApinResponse libraryEntitites.SignApinResponse
+
+	mu.Lock()
+	if atomic.LoadUint64(signInCount) > 0 {
+		atomic.AddUint64(signInCount, 1)
+		zapLogger.Debug(fmt.Sprintf("%v %v", "Already signed in", atomic.LoadUint64(signInCount)))
+		mu.Unlock()
+
+	} else {
+		signApinResponse, err = authenticationObj.GetPasswordSafeAuthentication()
+		if err != nil {
+			mu.Unlock()
+			zapLogger.Error(err.Error())
+			return libraryEntitites.SignApinResponse{}, err
+		}
+		atomic.AddUint64(signInCount, 1)
+		zapLogger.Debug(fmt.Sprintf("%v %v", "signin", atomic.LoadUint64(signInCount)))
+		mu.Unlock()
+	}
+
+	return signApinResponse, nil
+}
+
+// signOut sign Password Safe out
+func SignOut(authenticationObj auth.AuthenticationObj, muOut *sync.Mutex, signInCount *uint64, zapLogger logging.Logger) error {
+	var err error
+
+	muOut.Lock()
+	if atomic.LoadUint64(signInCount) > 1 {
+		zapLogger.Debug(fmt.Sprintf("%v %v", "Ignore signout", atomic.LoadUint64(signInCount)))
+		// decrement counter, don't signout.
+		atomic.AddUint64(signInCount, ^uint64(0))
+		muOut.Unlock()
+	} else {
+		err = authenticationObj.SignOut()
+		if err != nil {
+			return err
+		}
+		zapLogger.Debug(fmt.Sprintf("%v %v", "signout user", atomic.LoadUint64(signInCount)))
+		// decrement counter
+		atomic.AddUint64(signInCount, ^uint64(0))
+		muOut.Unlock()
+
+	}
+
+	return nil
+}

--- a/providers/utils/methods_test.go
+++ b/providers/utils/methods_test.go
@@ -1,0 +1,250 @@
+package utils
+
+import (
+	"net/http"
+	"net/http/httptest"
+	"net/url"
+	"strings"
+	"sync"
+	"terraform-provider-passwordsafe/providers/constants"
+	"terraform-provider-passwordsafe/providers/entities"
+	"testing"
+	"time"
+
+	"github.com/BeyondTrust/go-client-library-passwordsafe/api/authentication"
+	"github.com/BeyondTrust/go-client-library-passwordsafe/api/logging"
+	"github.com/BeyondTrust/go-client-library-passwordsafe/api/utils"
+	"github.com/cenkalti/backoff/v4"
+	"go.uber.org/zap"
+)
+
+var authParams *authentication.AuthenticationParametersObj
+var apiVersion string = "3.1"
+var zapLogger logging.Logger
+
+func TestTestResourceConfig(t *testing.T) {
+	config := entities.PasswordSafeTestConfig{
+		APIKey:                       "test-api-key",
+		ClientID:                     "test-client-id",
+		ClientSecret:                 "test-client-secret",
+		URL:                          "https://example.com",
+		APIAccountName:               "test-account",
+		ClientCertificatesFolderPath: "/path/to/certs",
+		ClientCertificateName:        "cert.pem",
+		ClientCertificatePassword:    "password123",
+		APIVersion:                   "v1",
+		Resource:                     "resource-content",
+	}
+
+	result := TestResourceConfig(config)
+
+	tests := []struct {
+		name     string
+		expected string
+	}{
+		{"APIKey", `api_key = "test-api-key"`},
+		{"ClientID", `client_id = "test-client-id"`},
+		{"ClientSecret", `client_secret = "test-client-secret"`},
+		{"URL", `url = "https://example.com"`},
+		{"APIAccountName", `api_account_name = "test-account"`},
+		{"ClientCertificatesFolderPath", `client_certificates_folder_path = "/path/to/certs"`},
+		{"ClientCertificateName", `client_certificate_name = "cert.pem"`},
+		{"ClientCertificatePassword", `client_certificate_password = "password123"`},
+		{"APIVersion", `api_version = "v1"`},
+		{"Resource", `resource-content`},
+	}
+
+	for _, tt := range tests {
+		if !strings.Contains(result, tt.expected) {
+			t.Errorf("Expected output to contain %s, but it was missing", tt.expected)
+		}
+	}
+}
+
+func InitializeGlobalConfig() {
+
+	logger, _ := zap.NewDevelopment()
+
+	zapLogger = logging.NewZapLogger(logger)
+
+	httpClientObj, _ := utils.GetHttpClient(5, false, "", "", zapLogger)
+
+	backoffDefinition := backoff.NewExponentialBackOff()
+	backoffDefinition.MaxElapsedTime = time.Second
+
+	authParams = &authentication.AuthenticationParametersObj{
+		HTTPClient:                 *httpClientObj,
+		BackoffDefinition:          backoffDefinition,
+		EndpointURL:                "https://fake.api.com:443/BeyondTrust/api/public/v3/",
+		APIVersion:                 apiVersion,
+		ClientID:                   "fakeone_a654+9sdf7+8we4f",
+		ClientSecret:               "fakeone_a654+9sdf7+8we4f",
+		ApiKey:                     "",
+		Logger:                     zapLogger,
+		RetryMaxElapsedTimeSeconds: 300,
+	}
+}
+
+func TestAutenticate(t *testing.T) {
+
+	InitializeGlobalConfig()
+
+	// mocking Password Safe API
+	server := httptest.NewTLSServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+
+		// mocking Response according to the endpoint path
+		switch r.URL.Path {
+		case constants.APIPath + "/Auth/connect/token":
+			_, err := w.Write([]byte(`{"access_token": "fake_token", "expires_in": 600, "token_type": "Bearer", "scope": "publicapi"}`))
+			if err != nil {
+				t.Error(err.Error())
+			}
+
+		case constants.APIPath + "/Auth/SignAppIn":
+			_, err := w.Write([]byte(`{"UserId":1, "EmailAddress":"test@beyondtrust.com"}`))
+
+			if err != nil {
+				t.Error(err.Error())
+			}
+
+		}
+
+	}))
+
+	var authenticateObj, _ = authentication.Authenticate(*authParams)
+	server.URL = server.URL + constants.APIPath
+	apiUrl, _ := url.Parse(server.URL)
+
+	authenticateObj.ApiUrl = *apiUrl
+
+	var signInCount uint64
+	var mu sync.Mutex
+
+	_, err := Autenticate(*authenticateObj, &mu, &signInCount, zapLogger)
+	if err != nil {
+		t.Error(err)
+	}
+
+	// Increment counter
+	_, err = Autenticate(*authenticateObj, &mu, &signInCount, zapLogger)
+	if err != nil {
+		t.Error(err)
+	}
+}
+
+func TestAutenticateErrorGettingToken(t *testing.T) {
+
+	InitializeGlobalConfig()
+
+	// mocking Password Safe API
+	server := httptest.NewTLSServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+
+		// mocking Response according to the endpoint path
+		switch r.URL.Path {
+		case constants.APIPath + "/Auth/connect/token":
+			w.WriteHeader(http.StatusBadRequest)
+			_, err := w.Write([]byte(`{"error": "invalid_client"}`))
+			if err != nil {
+				t.Error(err.Error())
+			}
+		}
+
+	}))
+
+	var authenticateObj, _ = authentication.Authenticate(*authParams)
+	server.URL = server.URL + constants.APIPath
+	apiUrl, _ := url.Parse(server.URL)
+
+	authenticateObj.ApiUrl = *apiUrl
+
+	var signInCount uint64
+	var mu sync.Mutex
+
+	expectedError := `error - status code: 400 - {"error": "invalid_client"}`
+
+	_, err := Autenticate(*authenticateObj, &mu, &signInCount, zapLogger)
+	if err.Error() != expectedError {
+		t.Errorf("Test case Failed %v, %v", err.Error(), expectedError)
+	}
+
+}
+
+func TestSignOut(t *testing.T) {
+
+	InitializeGlobalConfig()
+
+	// mocking Password Safe API
+	server := httptest.NewTLSServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+
+		// mocking Response according to the endpoint path
+		switch r.URL.Path {
+
+		case constants.APIPath + "/Auth/Signout":
+			_, err := w.Write([]byte(``))
+			if err != nil {
+				t.Error(err.Error())
+			}
+		}
+
+	}))
+
+	var authenticateObj, _ = authentication.Authenticate(*authParams)
+	server.URL = server.URL + constants.APIPath
+	apiUrl, _ := url.Parse(server.URL)
+
+	authenticateObj.ApiUrl = *apiUrl
+
+	var signInCount uint64
+	var muOut sync.Mutex
+
+	err := SignOut(*authenticateObj, &muOut, &signInCount, zapLogger)
+	if err != nil {
+		t.Error(err)
+	}
+
+	// decrement counter, don't signout case
+	err = SignOut(*authenticateObj, &muOut, &signInCount, zapLogger)
+	if err != nil {
+		t.Error(err)
+	}
+}
+
+func TestSignOutError(t *testing.T) {
+
+	InitializeGlobalConfig()
+
+	// mocking Password Safe API
+	server := httptest.NewTLSServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+
+		// mocking Response according to the endpoint path
+		switch r.URL.Path {
+
+		case constants.APIPath + "/Auth/Signout":
+			w.WriteHeader(http.StatusBadRequest)
+			_, err := w.Write([]byte(``))
+			if err != nil {
+				t.Error(err.Error())
+			}
+		}
+
+	}))
+
+	var authenticateObj, _ = authentication.Authenticate(*authParams)
+	server.URL = server.URL + constants.APIPath
+	apiUrl, _ := url.Parse(server.URL)
+
+	authenticateObj.ApiUrl = *apiUrl
+
+	var signInCount uint64
+	var muOut sync.Mutex
+
+	signInCount = 1
+
+	expectedError := `error - status code: 400 - `
+
+	err := SignOut(*authenticateObj, &muOut, &signInCount, zapLogger)
+	if err.Error() != expectedError {
+		t.Errorf("Test case Failed %v, %v", err.Error(), expectedError)
+	}
+
+}

--- a/terraform/main.tf
+++ b/terraform/main.tf
@@ -195,3 +195,7 @@ ephemeral "passwordsafe_secret_ephemeral" "secret" {
   path = "oauthgrp"
   title = "ephemeral_secret_title1"
 }
+
+resource "passwordsafe_workgroup" "workgroup" {
+  name = "workgroup name"
+}


### PR DESCRIPTION
### Purpose of the PR
Add creating Workgroups feature in terraform provider.

### According to ticket
<!-- Jira url or ticket number -->
https://beyondtrust.atlassian.net/browse/BIPS-23880

### Summary of changes:

- Call ValidationParams method to validate inputs in provider_framework and provider_sdkv2 providers.
- Create workgroup resource provider_framework provider.
- Create tests for new workgroup resource.
- Update go library version to v0.14.3 to v0.15.0 version.
- Improve code coverage in provider_framework provider.
- Create utils, constants and entities packages to centralize common components between providers.
- Making minor changes in provider_sdkv2 provider, (camel case variables).

