### PR TITLE
CI: [BIPS-27206] Hardening Github actions versions

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -121,7 +121,7 @@ jobs:
           fi
       
       - name: Get next version numbers
-        uses: reecetech/version-increment@a29aa752dc3b8118a2dc2ed93faf0e95a73a9c7e
+        uses: reecetech/version-increment@a29aa752dc3b8118a2dc2ed93faf0e95a73a9c7e # 2024.10.1
         id: version_number
         with:
           increment: ${{ steps.increment.outputs.increment }}

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -121,7 +121,7 @@ jobs:
           fi
       
       - name: Get next version numbers
-        uses: reecetech/version-increment@2024.10.1
+        uses: reecetech/version-increment@a29aa752dc3b8118a2dc2ed93faf0e95a73a9c7e
         id: version_number
         with:
           increment: ${{ steps.increment.outputs.increment }}


### PR DESCRIPTION
### Purpose of the PR
Update SHA github actions workflows versions

### According to ticket
[BIPS-27206](https://beyondtrust.atlassian.net/browse/BIPS-27206)

### Summary of changes:
- Versions changed from number to SHA commit ID


[BIPS-27206]: https://beyondtrust.atlassian.net/browse/BIPS-27206?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ