### PR TITLE
feat: Add support for API version (3.0, 3.1) in create credential, te…

### DIFF
--- a/providers/provider_sdkv2/common.go
+++ b/providers/provider_sdkv2/common.go
@@ -49,11 +49,23 @@ func getOwnersSchema() *schema.Schema {
 			Schema: map[string]*schema.Schema{
 				"owner_id": &schema.Schema{
 					Type:     schema.TypeInt,
-					Required: true,
+					Optional: true,
 				},
 				"owner": &schema.Schema{
 					Type:     schema.TypeString,
-					Required: true,
+					Optional: true,
+				},
+				"group_id": &schema.Schema{
+					Type:     schema.TypeInt,
+					Optional: true,
+				},
+				"user_id": &schema.Schema{
+					Type:     schema.TypeInt,
+					Optional: true,
+				},
+				"name": &schema.Schema{
+					Type:     schema.TypeString,
+					Optional: true,
 				},
 				"email": &schema.Schema{
 					Type:     schema.TypeString,

--- a/providers/utils/methods.go
+++ b/providers/utils/methods.go
@@ -44,10 +44,11 @@ func TestResourceConfig(config entities.PasswordSafeTestConfig) string {
 	)
 }
 
+var signAppinResponse libraryEntitites.SignAppinResponse
+
 // autenticate get Password Safe authentication.
 func Autenticate(authenticationObj auth.AuthenticationObj, mu *sync.Mutex, signInCount *uint64, zapLogger logging.Logger) (libraryEntitites.SignAppinResponse, error) {
 	var err error
-	var signAppinResponse libraryEntitites.SignAppinResponse
 
 	mu.Lock()
 	if atomic.LoadUint64(signInCount) > 0 {


### PR DESCRIPTION
### Purpose of the PR
Add support API support for the next resources, terraform project side.

### According to ticket
<!-- Jira url or ticket number -->
https://beyondtrust.atlassian.net/browse/BIPS-27413

### Summary of changes:

Add support API support for the next resources:

passwordsafe_credential_secret: https://docs.beyondtrust.com/bips/docs/secrets-safe-api#post-secrets-safefoldersfolderidguidsecrets 

passwordsafe_text_secret: https://docs.beyondtrust.com/bips/docs/secrets-safe-api#post-secrets-safefoldersfolderidguidsecretstext 

passwordsafe_file_secret: https://docs.beyondtrust.com/bips/docs/secrets-safe-api#post-secrets-safefoldersfolderidguidsecretsfile 