### PR TITLE
collapse signin/signout mutexes into a single authMu

### DIFF
--- a/providers/provider_framework/assets_datasource.go
+++ b/providers/provider_framework/assets_datasource.go
@@ -113,7 +113,7 @@ func (d *AssetDataSource) Read(ctx context.Context, req datasource.ReadRequest, 
 		return
 	}
 
-	_, err := utils.Authenticate(*d.providerInfo.authenticationObj, &mu, &signInCount, zapLogger)
+	_, err := utils.Authenticate(*d.providerInfo.authenticationObj, &authMu, &signInCount, zapLogger)
 	if err != nil {
 		resp.Diagnostics.AddError("Error getting Authentication", err.Error())
 		return

--- a/providers/provider_framework/assets_resource.go
+++ b/providers/provider_framework/assets_resource.go
@@ -71,7 +71,7 @@ func (r *assetResource) Delete(ctx context.Context, req resource.DeleteRequest, 
 		return
 	}
 
-	err := utils.DeleteAssetByID(*r.providerInfo.authenticationObj, data.AssetID.ValueInt32(), &mu, &muOut, &signInCount, zapLogger)
+	err := utils.DeleteAssetByID(*r.providerInfo.authenticationObj, data.AssetID.ValueInt32(), &authMu, &signInCount, zapLogger)
 	if err != nil {
 		resp.Diagnostics.AddError("Error deleting asset", err.Error())
 		return
@@ -149,7 +149,7 @@ func NewAssetByWorkgGroypIdResource() resource.Resource {
 
 func getAssetObj(resp *resource.CreateResponse, authenticationObj authentication.AuthenticationObj, dataInterface interface{}) *assets.AssetObj {
 
-	_, err := utils.Authenticate(authenticationObj, &mu, &signInCount, zapLogger)
+	_, err := utils.Authenticate(authenticationObj, &authMu, &signInCount, zapLogger)
 	if err != nil {
 		resp.Diagnostics.AddError("Error getting Authentication", err.Error())
 		return nil
@@ -195,7 +195,7 @@ func (r *assetResourceByWorkGroupId) Create(ctx context.Context, req resource.Cr
 
 	data.AssetID = types.Int32Value(int32(createdAsset.AssetID))
 
-	err = utils.SignOut(*r.providerInfo.authenticationObj, &muOut, &signInCount, zapLogger)
+	err = utils.SignOut(*r.providerInfo.authenticationObj, &authMu, &signInCount, zapLogger)
 	if err != nil {
 		resp.Diagnostics.AddError("Error Signing Out", err.Error())
 		return
@@ -213,7 +213,7 @@ func (r *assetResourceByWorkGroupId) Delete(ctx context.Context, req resource.De
 		return
 	}
 
-	err := utils.DeleteAssetByID(*r.providerInfo.authenticationObj, data.AssetID.ValueInt32(), &mu, &muOut, &signInCount, zapLogger)
+	err := utils.DeleteAssetByID(*r.providerInfo.authenticationObj, data.AssetID.ValueInt32(), &authMu, &signInCount, zapLogger)
 	if err != nil {
 		resp.Diagnostics.AddError("Error deleting asset", err.Error())
 		return
@@ -316,7 +316,7 @@ func (r *assetResourceByWorkGroupName) Create(ctx context.Context, req resource.
 
 	data.AssetID = types.Int32Value(int32(createdAsset.AssetID))
 
-	err = utils.SignOut(*r.providerInfo.authenticationObj, &muOut, &signInCount, zapLogger)
+	err = utils.SignOut(*r.providerInfo.authenticationObj, &authMu, &signInCount, zapLogger)
 	if err != nil {
 		resp.Diagnostics.AddError("Error Signing Out", err.Error())
 		return
@@ -334,7 +334,7 @@ func (r *assetResourceByWorkGroupName) Delete(ctx context.Context, req resource.
 		return
 	}
 
-	err := utils.DeleteAssetByID(*r.providerInfo.authenticationObj, data.AssetID.ValueInt32(), &mu, &muOut, &signInCount, zapLogger)
+	err := utils.DeleteAssetByID(*r.providerInfo.authenticationObj, data.AssetID.ValueInt32(), &authMu, &signInCount, zapLogger)
 	if err != nil {
 		resp.Diagnostics.AddError("Error deleting asset", err.Error())
 		return

--- a/providers/provider_framework/databases_datasource.go
+++ b/providers/provider_framework/databases_datasource.go
@@ -92,7 +92,7 @@ func (d *DatabaseDataSource) Read(ctx context.Context, req datasource.ReadReques
 		return
 	}
 
-	_, err := utils.Authenticate(*d.providerInfo.authenticationObj, &mu, &signInCount, zapLogger)
+	_, err := utils.Authenticate(*d.providerInfo.authenticationObj, &authMu, &signInCount, zapLogger)
 	if err != nil {
 		resp.Diagnostics.AddError("Error getting Authentication", err.Error())
 		return

--- a/providers/provider_framework/databases_resource.go
+++ b/providers/provider_framework/databases_resource.go
@@ -107,7 +107,7 @@ func (r *databaseResource) Create(ctx context.Context, req resource.CreateReques
 		return
 	}
 
-	_, err := utils.Authenticate(*r.providerInfo.authenticationObj, &mu, &signInCount, zapLogger)
+	_, err := utils.Authenticate(*r.providerInfo.authenticationObj, &authMu, &signInCount, zapLogger)
 	if err != nil {
 		resp.Diagnostics.AddError("Error getting Authentication", err.Error())
 		return
@@ -140,7 +140,7 @@ func (r *databaseResource) Create(ctx context.Context, req resource.CreateReques
 
 	data.DatabaseID = types.Int32Value(int32(createdDataBase.DatabaseID))
 
-	err = utils.SignOut(*r.providerInfo.authenticationObj, &muOut, &signInCount, zapLogger)
+	err = utils.SignOut(*r.providerInfo.authenticationObj, &authMu, &signInCount, zapLogger)
 	if err != nil {
 		resp.Diagnostics.AddError("Error Signing Out", err.Error())
 		return
@@ -166,7 +166,7 @@ func (r *databaseResource) Delete(ctx context.Context, req resource.DeleteReques
 		return
 	}
 
-	_, err := utils.Authenticate(*r.providerInfo.authenticationObj, &mu, &signInCount, zapLogger)
+	_, err := utils.Authenticate(*r.providerInfo.authenticationObj, &authMu, &signInCount, zapLogger)
 	if err != nil {
 		resp.Diagnostics.AddError("Error getting Authentication", err.Error())
 		return
@@ -186,7 +186,7 @@ func (r *databaseResource) Delete(ctx context.Context, req resource.DeleteReques
 		return
 	}
 
-	err = utils.SignOut(*r.providerInfo.authenticationObj, &muOut, &signInCount, zapLogger)
+	err = utils.SignOut(*r.providerInfo.authenticationObj, &authMu, &signInCount, zapLogger)
 	if err != nil {
 		resp.Diagnostics.AddError("Error Signing Out", err.Error())
 		return

--- a/providers/provider_framework/folders_datasource.go
+++ b/providers/provider_framework/folders_datasource.go
@@ -96,7 +96,7 @@ func (d *FolderDataSource) Read(ctx context.Context, req datasource.ReadRequest,
 		return
 	}
 
-	_, err := utils.Authenticate(*d.providerInfo.authenticationObj, &mu, &signInCount, zapLogger)
+	_, err := utils.Authenticate(*d.providerInfo.authenticationObj, &authMu, &signInCount, zapLogger)
 	if err != nil {
 		resp.Diagnostics.AddError("Error getting Authentication", err.Error())
 		return

--- a/providers/provider_framework/functional_accounts_datasource.go
+++ b/providers/provider_framework/functional_accounts_datasource.go
@@ -80,7 +80,7 @@ func (d *FunctionalAccountDataResource) Read(ctx context.Context, req datasource
 		return
 	}
 
-	_, err := utils.Authenticate(*d.providerInfo.authenticationObj, &mu, &signInCount, zapLogger)
+	_, err := utils.Authenticate(*d.providerInfo.authenticationObj, &authMu, &signInCount, zapLogger)
 	if err != nil {
 		resp.Diagnostics.AddError("Error getting Authentication", err.Error())
 		return

--- a/providers/provider_framework/functional_accounts_resource.go
+++ b/providers/provider_framework/functional_accounts_resource.go
@@ -146,7 +146,7 @@ func (r *FunctionalAccountResource) Create(ctx context.Context, req resource.Cre
 		return
 	}
 
-	_, err := utils.Authenticate(*r.providerInfo.authenticationObj, &mu, &signInCount, zapLogger)
+	_, err := utils.Authenticate(*r.providerInfo.authenticationObj, &authMu, &signInCount, zapLogger)
 	if err != nil {
 		resp.Diagnostics.AddError("Error getting Authentication", err.Error())
 		return
@@ -187,7 +187,7 @@ func (r *FunctionalAccountResource) Create(ctx context.Context, req resource.Cre
 
 	data.FunctionalAccountID = types.Int32Value(int32(createdFunctionalAccount.FunctionalAccountID))
 
-	err = utils.SignOut(*r.providerInfo.authenticationObj, &muOut, &signInCount, zapLogger)
+	err = utils.SignOut(*r.providerInfo.authenticationObj, &authMu, &signInCount, zapLogger)
 	if err != nil {
 		resp.Diagnostics.AddError("Error Signing Out", err.Error())
 		return
@@ -214,7 +214,7 @@ func (r *FunctionalAccountResource) Delete(ctx context.Context, req resource.Del
 		return
 	}
 
-	_, err := utils.Authenticate(*r.providerInfo.authenticationObj, &mu, &signInCount, zapLogger)
+	_, err := utils.Authenticate(*r.providerInfo.authenticationObj, &authMu, &signInCount, zapLogger)
 	if err != nil {
 		resp.Diagnostics.AddError("Error getting Authentication", err.Error())
 		return
@@ -234,7 +234,7 @@ func (r *FunctionalAccountResource) Delete(ctx context.Context, req resource.Del
 		return
 	}
 
-	err = utils.SignOut(*r.providerInfo.authenticationObj, &muOut, &signInCount, zapLogger)
+	err = utils.SignOut(*r.providerInfo.authenticationObj, &authMu, &signInCount, zapLogger)
 	if err != nil {
 		resp.Diagnostics.AddError("Error Signing Out", err.Error())
 		return

--- a/providers/provider_framework/managed_account_datasource.go
+++ b/providers/provider_framework/managed_account_datasource.go
@@ -114,7 +114,7 @@ func (d *ManagedAccountDataSource) Read(ctx context.Context, req datasource.Read
 		return
 	}
 
-	_, err := utils.Authenticate(*d.providerInfo.authenticationObj, &mu, &signInCount, zapLogger)
+	_, err := utils.Authenticate(*d.providerInfo.authenticationObj, &authMu, &signInCount, zapLogger)
 	if err != nil {
 		resp.Diagnostics.AddError("Error getting Authentication", err.Error())
 		return

--- a/providers/provider_framework/managed_account_ephemeral.go
+++ b/providers/provider_framework/managed_account_ephemeral.go
@@ -85,7 +85,7 @@ func (e *EphemeralManagedAccount) Open(ctx context.Context, request ephemeral.Op
 		return
 	}
 
-	_, err := utils.Authenticate(*e.providerInfo.authenticationObj, &mu, &signInCount, zapLogger)
+	_, err := utils.Authenticate(*e.providerInfo.authenticationObj, &authMu, &signInCount, zapLogger)
 	if err != nil {
 		response.Diagnostics.AddError("Error getting Authentication", err.Error())
 		return
@@ -110,7 +110,7 @@ func (e *EphemeralManagedAccount) Open(ctx context.Context, request ephemeral.Op
 	// setting secret to value attribute
 	data.Value = types.StringValue(gotManagedAccount)
 
-	err = utils.SignOut(*e.providerInfo.authenticationObj, &muOut, &signInCount, zapLogger)
+	err = utils.SignOut(*e.providerInfo.authenticationObj, &authMu, &signInCount, zapLogger)
 	if err != nil {
 		response.Diagnostics.AddError("Error Signing Out", err.Error())
 		return

--- a/providers/provider_framework/managed_system_datasource.go
+++ b/providers/provider_framework/managed_system_datasource.go
@@ -161,7 +161,7 @@ func (d *ManagedSystemDataSource) Read(ctx context.Context, req datasource.ReadR
 		return
 	}
 
-	_, err := utils.Authenticate(*d.providerInfo.authenticationObj, &mu, &signInCount, zapLogger)
+	_, err := utils.Authenticate(*d.providerInfo.authenticationObj, &authMu, &signInCount, zapLogger)
 	if err != nil {
 		resp.Diagnostics.AddError("Error getting Authentication", err.Error())
 		return

--- a/providers/provider_framework/managed_systems_by_asset_resource.go
+++ b/providers/provider_framework/managed_systems_by_asset_resource.go
@@ -241,7 +241,7 @@ func (r *managedSystemResource) Delete(ctx context.Context, req resource.DeleteR
 		return
 	}
 
-	_, err := utils.Authenticate(*r.providerInfo.authenticationObj, &mu, &signInCount, zapLogger)
+	_, err := utils.Authenticate(*r.providerInfo.authenticationObj, &authMu, &signInCount, zapLogger)
 	if err != nil {
 		resp.Diagnostics.AddError("Error getting Authentication", err.Error())
 		return
@@ -254,7 +254,7 @@ func (r *managedSystemResource) Delete(ctx context.Context, req resource.DeleteR
 		return
 	}
 
-	err = utils.SignOut(*r.providerInfo.authenticationObj, &muOut, &signInCount, zapLogger)
+	err = utils.SignOut(*r.providerInfo.authenticationObj, &authMu, &signInCount, zapLogger)
 	if err != nil {
 		resp.Diagnostics.AddError("Error Signing Out", err.Error())
 		return

--- a/providers/provider_framework/managed_systems_by_database_resource.go
+++ b/providers/provider_framework/managed_systems_by_database_resource.go
@@ -152,7 +152,7 @@ func (r *managedSystemByDatabaseResource) Delete(ctx context.Context, req resour
 		return
 	}
 
-	_, err := utils.Authenticate(*r.providerInfo.authenticationObj, &mu, &signInCount, zapLogger)
+	_, err := utils.Authenticate(*r.providerInfo.authenticationObj, &authMu, &signInCount, zapLogger)
 	if err != nil {
 		resp.Diagnostics.AddError("Error getting Authentication", err.Error())
 		return
@@ -165,7 +165,7 @@ func (r *managedSystemByDatabaseResource) Delete(ctx context.Context, req resour
 		return
 	}
 
-	err = utils.SignOut(*r.providerInfo.authenticationObj, &muOut, &signInCount, zapLogger)
+	err = utils.SignOut(*r.providerInfo.authenticationObj, &authMu, &signInCount, zapLogger)
 	if err != nil {
 		resp.Diagnostics.AddError("Error Signing Out", err.Error())
 		return
@@ -185,7 +185,7 @@ func getManagedSystemObj(changeFrequencyType string, changeFrequencyDays int, re
 		return nil, err
 	}
 
-	_, err = utils.Authenticate(authenticationObj, &mu, &signInCount, zapLogger)
+	_, err = utils.Authenticate(authenticationObj, &authMu, &signInCount, zapLogger)
 	if err != nil {
 		resp.Diagnostics.AddError("Error getting Authentication", err.Error())
 		return nil, err
@@ -203,7 +203,7 @@ func getManagedSystemObj(changeFrequencyType string, changeFrequencyDays int, re
 
 // APISignOut close connection with Password Safe API.
 func APISignOut(resp *resource.CreateResponse, authenticationObj authentication.AuthenticationObj) {
-	err := utils.SignOut(authenticationObj, &muOut, &signInCount, zapLogger)
+	err := utils.SignOut(authenticationObj, &authMu, &signInCount, zapLogger)
 	if err != nil {
 		resp.Diagnostics.AddError("Error Signing Out", err.Error())
 		return

--- a/providers/provider_framework/managed_systems_by_workgroup_resource.go
+++ b/providers/provider_framework/managed_systems_by_workgroup_resource.go
@@ -331,7 +331,7 @@ func (r *managedSystemByWorkGroupResource) Delete(ctx context.Context, req resou
 		return
 	}
 
-	_, err := utils.Authenticate(*r.providerInfo.authenticationObj, &mu, &signInCount, zapLogger)
+	_, err := utils.Authenticate(*r.providerInfo.authenticationObj, &authMu, &signInCount, zapLogger)
 	if err != nil {
 		resp.Diagnostics.AddError("Error getting Authentication", err.Error())
 		return
@@ -344,7 +344,7 @@ func (r *managedSystemByWorkGroupResource) Delete(ctx context.Context, req resou
 		return
 	}
 
-	err = utils.SignOut(*r.providerInfo.authenticationObj, &muOut, &signInCount, zapLogger)
+	err = utils.SignOut(*r.providerInfo.authenticationObj, &authMu, &signInCount, zapLogger)
 	if err != nil {
 		resp.Diagnostics.AddError("Error Signing Out", err.Error())
 		return

--- a/providers/provider_framework/platforms_datasource.go
+++ b/providers/provider_framework/platforms_datasource.go
@@ -164,7 +164,7 @@ func (d *PlatformDataSource) Read(ctx context.Context, req datasource.ReadReques
 		return
 	}
 
-	_, err := utils.Authenticate(*d.providerInfo.authenticationObj, &mu, &signInCount, zapLogger)
+	_, err := utils.Authenticate(*d.providerInfo.authenticationObj, &authMu, &signInCount, zapLogger)
 	if err != nil {
 		resp.Diagnostics.AddError("Error getting Authentication", err.Error())
 		return

--- a/providers/provider_framework/provider.go
+++ b/providers/provider_framework/provider.go
@@ -35,8 +35,7 @@ var (
 )
 
 var signInCount uint64
-var mu sync.Mutex
-var muOut sync.Mutex
+var authMu sync.Mutex
 
 type PasswordSafeProvider struct {
 }

--- a/providers/provider_framework/safes_datasources.go
+++ b/providers/provider_framework/safes_datasources.go
@@ -87,7 +87,7 @@ func (d *SafesDataSource) Read(ctx context.Context, req datasource.ReadRequest, 
 		return
 	}
 
-	_, err := utils.Authenticate(*d.providerInfo.authenticationObj, &mu, &signInCount, zapLogger)
+	_, err := utils.Authenticate(*d.providerInfo.authenticationObj, &authMu, &signInCount, zapLogger)
 	if err != nil {
 		resp.Diagnostics.AddError("Error getting Authentication", err.Error())
 		return

--- a/providers/provider_framework/secrets_ephemeral.go
+++ b/providers/provider_framework/secrets_ephemeral.go
@@ -98,7 +98,7 @@ func (e *EphemeralSecret) Open(ctx context.Context, request ephemeral.OpenReques
 		return
 	}
 
-	_, err := utils.Authenticate(*e.providerInfo.authenticationObj, &mu, &signInCount, zapLogger)
+	_, err := utils.Authenticate(*e.providerInfo.authenticationObj, &authMu, &signInCount, zapLogger)
 	if err != nil {
 		response.Diagnostics.AddError("Error getting Authentication", err.Error())
 		return
@@ -134,7 +134,7 @@ func (e *EphemeralSecret) Open(ctx context.Context, request ephemeral.OpenReques
 	// setting secret to value attribute
 	data.Value = types.StringValue(secret)
 
-	err = utils.SignOut(*e.providerInfo.authenticationObj, &muOut, &signInCount, zapLogger)
+	err = utils.SignOut(*e.providerInfo.authenticationObj, &authMu, &signInCount, zapLogger)
 	if err != nil {
 		response.Diagnostics.AddError("Error Signing Out", err.Error())
 		return

--- a/providers/provider_framework/workgroups_datasources.go
+++ b/providers/provider_framework/workgroups_datasources.go
@@ -85,7 +85,7 @@ func (d *WorkgroupDataSource) Read(ctx context.Context, req datasource.ReadReque
 		return
 	}
 
-	_, err := utils.Authenticate(*d.providerInfo.authenticationObj, &mu, &signInCount, zapLogger)
+	_, err := utils.Authenticate(*d.providerInfo.authenticationObj, &authMu, &signInCount, zapLogger)
 	if err != nil {
 		resp.Diagnostics.AddError("Error getting Authentication", err.Error())
 		return

--- a/providers/provider_framework/workgroups_resource.go
+++ b/providers/provider_framework/workgroups_resource.go
@@ -83,7 +83,7 @@ func (r *WorkGroupResource) Create(ctx context.Context, req resource.CreateReque
 		return
 	}
 
-	_, err := utils.Authenticate(*r.providerInfo.authenticationObj, &mu, &signInCount, zapLogger)
+	_, err := utils.Authenticate(*r.providerInfo.authenticationObj, &authMu, &signInCount, zapLogger)
 	if err != nil {
 		resp.Diagnostics.AddError("Error getting Authentication", err.Error())
 		return
@@ -116,7 +116,7 @@ func (r *WorkGroupResource) Create(ctx context.Context, req resource.CreateReque
 
 	data.Id = types.Int32Value(int32(createdWorkGroup.ID))
 
-	err = utils.SignOut(*r.providerInfo.authenticationObj, &muOut, &signInCount, zapLogger)
+	err = utils.SignOut(*r.providerInfo.authenticationObj, &authMu, &signInCount, zapLogger)
 	if err != nil {
 		resp.Diagnostics.AddError("Error Signing Out", err.Error())
 		return

--- a/providers/provider_sdkv2/common.go
+++ b/providers/provider_sdkv2/common.go
@@ -16,7 +16,7 @@ func authenticate(d *schema.ResourceData, m interface{}) (entities.SignAppinResp
 	var err error
 	var signAppinResponse entities.SignAppinResponse
 
-	signAppinResponse, err = utils.Authenticate(*authenticationObj, &mu, &signInCount, zapLogger)
+	signAppinResponse, err = utils.Authenticate(*authenticationObj, &authMu, &signInCount, zapLogger)
 	if err != nil {
 		zapLogger.Error(err.Error())
 		return signAppinResponse, err
@@ -29,7 +29,7 @@ func authenticate(d *schema.ResourceData, m interface{}) (entities.SignAppinResp
 func signOut(d *schema.ResourceData, m interface{}) error {
 	authenticationObj := m.(*auth.AuthenticationObj)
 
-	err := utils.SignOut(*authenticationObj, &muOut, &signInCount, zapLogger)
+	err := utils.SignOut(*authenticationObj, &authMu, &signInCount, zapLogger)
 	if err != nil {
 		zapLogger.Error(err.Error())
 		return err
@@ -116,8 +116,8 @@ func getManagedAccountSchema() map[string]*schema.Schema {
 			Required: true,
 		},
 		"password": &schema.Schema{
-			Type:     schema.TypeString,
-			Required: true,
+			Type:      schema.TypeString,
+			Required:  true,
 			Sensitive: true,
 		},
 		"domain_name": &schema.Schema{

--- a/providers/provider_sdkv2/provider.go
+++ b/providers/provider_sdkv2/provider.go
@@ -20,8 +20,7 @@ import (
 )
 
 var signInCount uint64
-var mu sync.Mutex
-var muOut sync.Mutex
+var authMu sync.Mutex
 
 // Define the zap configuration
 var config = zap.Config{

--- a/providers/utils/methods.go
+++ b/providers/utils/methods.go
@@ -6,7 +6,6 @@ import (
 	"errors"
 	"fmt"
 	"sync"
-	"sync/atomic"
 	"terraform-provider-passwordsafe/providers/entities"
 
 	"github.com/BeyondTrust/go-client-library-passwordsafe/api/assets"
@@ -47,53 +46,52 @@ func TestResourceConfig(config entities.PasswordSafeTestConfig) string {
 
 var signAppinResponse libraryEntitites.SignAppinResponse
 
-// authenticate get Password Safe authentication.
+// Authenticate gets Password Safe authentication, sharing a session across
+// concurrent callers via the reference count guarded by mu.
 func Authenticate(authenticationObj auth.AuthenticationObj, mu *sync.Mutex, signInCount *uint64, zapLogger logging.Logger) (libraryEntitites.SignAppinResponse, error) {
-	var err error
-
 	mu.Lock()
-	if atomic.LoadUint64(signInCount) > 0 {
-		atomic.AddUint64(signInCount, 1)
-		zapLogger.Debug(fmt.Sprintf("%v %v", "Already signed in", atomic.LoadUint64(signInCount)))
-		mu.Unlock()
+	defer mu.Unlock()
 
-	} else {
-		signAppinResponse, err = authenticationObj.GetPasswordSafeAuthentication()
-		if err != nil {
-			mu.Unlock()
-			zapLogger.Error(err.Error())
-			return libraryEntitites.SignAppinResponse{}, err
-		}
-		atomic.AddUint64(signInCount, 1)
-		zapLogger.Debug(fmt.Sprintf("%v %v", "signin", atomic.LoadUint64(signInCount)))
-		mu.Unlock()
+	if *signInCount > 0 {
+		*signInCount++
+		zapLogger.Debug(fmt.Sprintf("%v %v", "Already signed in", *signInCount))
+		return signAppinResponse, nil
 	}
 
+	resp, err := authenticationObj.GetPasswordSafeAuthentication()
+	if err != nil {
+		zapLogger.Error(err.Error())
+		return libraryEntitites.SignAppinResponse{}, err
+	}
+	signAppinResponse = resp
+	*signInCount++
+	zapLogger.Debug(fmt.Sprintf("%v %v", "signin", *signInCount))
 	return signAppinResponse, nil
 }
 
-// signOut sign Password Safe out
-func SignOut(authenticationObj auth.AuthenticationObj, muOut *sync.Mutex, signInCount *uint64, zapLogger logging.Logger) error {
-	var err error
+// SignOut releases this caller's reference to the shared session. The same
+// mutex used by Authenticate must be passed in so signin and signout can never
+// run concurrently — the API's signout is user-global and would otherwise tear
+// down a session another worker is racing to use.
+func SignOut(authenticationObj auth.AuthenticationObj, mu *sync.Mutex, signInCount *uint64, zapLogger logging.Logger) error {
+	mu.Lock()
+	defer mu.Unlock()
 
-	muOut.Lock()
-	if atomic.LoadUint64(signInCount) > 1 {
-		zapLogger.Debug(fmt.Sprintf("%v %v", "Ignore signout", atomic.LoadUint64(signInCount)))
-		// decrement counter, don't signout.
-		atomic.AddUint64(signInCount, ^uint64(0))
-		muOut.Unlock()
-	} else {
-		err = authenticationObj.SignOut()
-		if err != nil {
-			return err
-		}
-		zapLogger.Debug(fmt.Sprintf("%v %v", "signout user", atomic.LoadUint64(signInCount)))
-		// decrement counter
-		atomic.AddUint64(signInCount, ^uint64(0))
-		muOut.Unlock()
-
+	if *signInCount > 1 {
+		zapLogger.Debug(fmt.Sprintf("%v %v", "Ignore signout", *signInCount))
+		*signInCount--
+		return nil
 	}
 
+	err := authenticationObj.SignOut()
+	// Decrement regardless of error: this caller is leaving, and on signout
+	// failure the cached session state is unreliable, so the next Authenticate
+	// should establish a fresh one.
+	*signInCount--
+	if err != nil {
+		return err
+	}
+	zapLogger.Debug(fmt.Sprintf("%v %v", "signout user", *signInCount))
 	return nil
 }
 
@@ -108,7 +106,7 @@ func ValidateChangeFrequencyDays(changeFrequencyType string, changeFrequencyDays
 }
 
 // DeleteAssetByID deletes an asset by its ID using the provided authentication object
-func DeleteAssetByID(authenticationObj auth.AuthenticationObj, assetID int32, mu *sync.Mutex, muOut *sync.Mutex, signInCount *uint64, zapLogger logging.Logger) error {
+func DeleteAssetByID(authenticationObj auth.AuthenticationObj, assetID int32, mu *sync.Mutex, signInCount *uint64, zapLogger logging.Logger) error {
 	_, err := Authenticate(authenticationObj, mu, signInCount, zapLogger)
 	if err != nil {
 		return fmt.Errorf("error getting Authentication: %w", err)
@@ -126,7 +124,7 @@ func DeleteAssetByID(authenticationObj auth.AuthenticationObj, assetID int32, mu
 		return fmt.Errorf("error deleting asset: %w", err)
 	}
 
-	err = SignOut(authenticationObj, muOut, signInCount, zapLogger)
+	err = SignOut(authenticationObj, mu, signInCount, zapLogger)
 	if err != nil {
 		return fmt.Errorf("error signing out: %w", err)
 	}

--- a/providers/utils/methods_test.go
+++ b/providers/utils/methods_test.go
@@ -196,15 +196,15 @@ func TestSignOut(t *testing.T) {
 	authenticateObj.ApiUrl = *apiUrl
 
 	var signInCount uint64
-	var muOut sync.Mutex
+	var mu sync.Mutex
 
-	err := SignOut(*authenticateObj, &muOut, &signInCount, zapLogger)
+	err := SignOut(*authenticateObj, &mu, &signInCount, zapLogger)
 	if err != nil {
 		t.Error(err)
 	}
 
 	// decrement counter, don't signout case
-	err = SignOut(*authenticateObj, &muOut, &signInCount, zapLogger)
+	err = SignOut(*authenticateObj, &mu, &signInCount, zapLogger)
 	if err != nil {
 		t.Error(err)
 	}
@@ -237,13 +237,13 @@ func TestSignOutError(t *testing.T) {
 	authenticateObj.ApiUrl = *apiUrl
 
 	var signInCount uint64
-	var muOut sync.Mutex
+	var mu sync.Mutex
 
 	signInCount = 1
 
 	expectedError := `error - status code: 400 - `
 
-	err := SignOut(*authenticateObj, &muOut, &signInCount, zapLogger)
+	err := SignOut(*authenticateObj, &mu, &signInCount, zapLogger)
 	if err.Error() != expectedError {
 		t.Errorf("Test case Failed %v, %v", err.Error(), expectedError)
 	}
@@ -676,9 +676,8 @@ func TestDeleteAssetByID(t *testing.T) {
 
 		var signInCount uint64
 		var mu sync.Mutex
-		var muOut sync.Mutex
 
-		err := DeleteAssetByID(*authenticateObj, 123, &mu, &muOut, &signInCount, zapLogger)
+		err := DeleteAssetByID(*authenticateObj, 123, &mu, &signInCount, zapLogger)
 		if err != nil {
 			t.Errorf("Expected no error, but got: %s", err.Error())
 		}
@@ -722,9 +721,8 @@ func TestDeleteAssetByID(t *testing.T) {
 
 		var signInCount uint64
 		var mu sync.Mutex
-		var muOut sync.Mutex
 
-		err := DeleteAssetByID(*authenticateObj, 123, &mu, &muOut, &signInCount, zapLogger)
+		err := DeleteAssetByID(*authenticateObj, 123, &mu, &signInCount, zapLogger)
 		if err == nil {
 			t.Error("Expected error when deleting asset, but got none")
 		}
@@ -751,9 +749,8 @@ func TestDeleteAssetByID(t *testing.T) {
 
 		var signInCount uint64
 		var mu sync.Mutex
-		var muOut sync.Mutex
 
-		err := DeleteAssetByID(*authenticateObj, 123, &mu, &muOut, &signInCount, zapLogger)
+		err := DeleteAssetByID(*authenticateObj, 123, &mu, &signInCount, zapLogger)
 		if err == nil {
 			t.Error("Expected error due to authentication failure, but got none")
 		}


### PR DESCRIPTION
## Purpose of the PR

- Fix the race between concurrent signin and signout that intermittently caused "user is signed out" failures during `terraform apply`.

## Linked JIRA issue(s)

- none

## Summary of changes

The provider used two separate mutexes (`mu` for signin, `muOut` for signout) to guard a shared, reference-counted PasswordSafe session. Because the two functions never blocked each other, a worker could enter `Authenticate`, observe `signInCount == 1`, and skip the real signin while another worker was mid-`SignOut` — tearing down the user-global session the first worker was about to use. Subsequent API calls returned 401 "user is signed out". The race window was the full duration of the signout HTTP round-trip, and Terraform's default 10-worker concurrency made it hittable on the boundary between resource batches.

This change:

- Collapses `mu` and `muOut` into a single `authMu` in both provider variants (`provider_sdkv2` and `provider_framework`), so signin and signout can never run concurrently.
- Rewrites `utils.Authenticate` and `utils.SignOut` to take the single mutex and use `defer mu.Unlock()`, which also closes a latent deadlock where `SignOut` returned without unlocking when the API call errored.
- Decrements `signInCount` even when `SignOut`'s API call fails, so a transient signout error no longer pins the counter at 1 and starves all subsequent signins.
- Drops the now-redundant `sync/atomic` calls (the mutex serializes the read-decide-act sequence the atomics couldn't).
- Updates `utils.DeleteAssetByID` and all call sites (~30) across both provider variants to pass the single mutex.

Affected areas: every CRUD path in both provider variants, since they all sandwich their work between `utils.Authenticate` and `utils.SignOut`. No behavior change for callers — same signature shape, just one fewer mutex parameter on `DeleteAssetByID`.

## Checklist

### Release

- [ ]  Priority release required due to Hot fix / Escalation / Critical bug
- [ ]  Priority release not required (can be released later with other stories or bugs fixes)

### Testing

- [x] dev — `go build`, `go vet`, and `go test ./...` all pass locally. The race itself is timing-dependent and not reproducible in unit tests; it should be exercised against a real PasswordSafe instance under concurrent load (e.g. a plan with ≥10 resources) to confirm the "user is signed out" failures no longer occur.
- [ ] automation
- [ ] manual

### Automation

- [x] existing tests have been updated
- [ ] no changes are required
- [ ] new tests have been added
- [ ] further changes are required by the automation team