### PR TITLE
fix: BIPS-35966/35972/35987/35993/35997 security and correctness fixes

### DIFF
--- a/providers/provider_framework/provider.go
+++ b/providers/provider_framework/provider.go
@@ -170,6 +170,24 @@ func (p *PasswordSafeProvider) GetCertificateData(resp *provider.ConfigureRespon
 	return "", ""
 }
 
+func (p *PasswordSafeProvider) buildAuthenticationObj(httpClient utils.HttpClientObj, backoffDefinition *backoff.ExponentialBackOff, data ProviderModel) (*auth.AuthenticationObj, error) {
+	base := auth.AuthenticationParametersObj{
+		HTTPClient:                 httpClient,
+		BackoffDefinition:          backoffDefinition,
+		EndpointURL:                strings.TrimSpace(data.Url.ValueString()),
+		APIVersion:                 data.APIVersion.ValueString(),
+		Logger:                     zapLogger,
+		RetryMaxElapsedTimeSeconds: 30,
+	}
+	if data.APIKey.ValueString() != "" {
+		base.ApiKey = fmt.Sprintf("%v;runas=%v;", strings.TrimSpace(data.APIKey.ValueString()), strings.TrimSpace(data.APIAccountName.ValueString()))
+		return auth.AuthenticateUsingApiKey(base)
+	}
+	base.ClientID = data.ClientId.ValueString()
+	base.ClientSecret = data.ClientSecret.ValueString()
+	return auth.Authenticate(base)
+}
+
 func (p *PasswordSafeProvider) Configure(ctx context.Context, req provider.ConfigureRequest, resp *provider.ConfigureResponse) {
 
 	var data ProviderModel
@@ -238,42 +256,10 @@ func (p *PasswordSafeProvider) Configure(ctx context.Context, req provider.Confi
 		return
 	}
 
-	var authenticate *auth.AuthenticationObj
-
-	// authenticate using api key
-	if providerData.apiKey != "" {
-		authParamsApiKey := &auth.AuthenticationParametersObj{
-			HTTPClient:                 *httpClientObj,
-			BackoffDefinition:          backoffDefinition,
-			EndpointURL:                strings.TrimSpace(data.Url.ValueString()),
-			APIVersion:                 data.APIVersion.ValueString(),
-			ClientID:                   "",
-			ClientSecret:               "",
-			ApiKey:                     fmt.Sprintf("%v;runas=%v;", strings.TrimSpace(data.APIKey.ValueString()), strings.TrimSpace(data.APIAccountName.ValueString())),
-			Logger:                     zapLogger,
-			RetryMaxElapsedTimeSeconds: 30,
-		}
-		authenticate, err = auth.AuthenticateUsingApiKey(*authParamsApiKey)
-		if err != nil {
-			resp.Diagnostics.AddError("Error in Provider", err.Error())
-		}
-	} else {
-		// authenticate using client_id and client secret
-		authParamsOauth := &auth.AuthenticationParametersObj{
-			HTTPClient:                 *httpClientObj,
-			BackoffDefinition:          backoffDefinition,
-			EndpointURL:                strings.TrimSpace(data.Url.ValueString()),
-			APIVersion:                 data.APIVersion.ValueString(),
-			ClientID:                   data.ClientId.ValueString(),
-			ClientSecret:               data.ClientSecret.ValueString(),
-			ApiKey:                     "",
-			Logger:                     zapLogger,
-			RetryMaxElapsedTimeSeconds: 30,
-		}
-		authenticate, err = auth.Authenticate(*authParamsOauth)
-		if err != nil {
-			resp.Diagnostics.AddError("Error in Provider", err.Error())
-		}
+	authenticate, err := p.buildAuthenticationObj(*httpClientObj, backoffDefinition, data)
+	if err != nil {
+		resp.Diagnostics.AddError("Error in Provider", err.Error())
+		return
 	}
 
 	// authenticating

--- a/providers/provider_framework/provider.go
+++ b/providers/provider_framework/provider.go
@@ -179,7 +179,7 @@ func (p *PasswordSafeProvider) buildAuthenticationObj(httpClient utils.HttpClien
 		Logger:                     zapLogger,
 		RetryMaxElapsedTimeSeconds: 30,
 	}
-	if data.APIKey.ValueString() != "" {
+	if strings.TrimSpace(data.APIKey.ValueString()) != "" {
 		base.ApiKey = fmt.Sprintf("%v;runas=%v;", strings.TrimSpace(data.APIKey.ValueString()), strings.TrimSpace(data.APIAccountName.ValueString()))
 		return auth.AuthenticateUsingApiKey(base)
 	}

--- a/providers/provider_framework/provider.go
+++ b/providers/provider_framework/provider.go
@@ -29,7 +29,6 @@ import (
 var (
 	maxFileSecretSizeBytes     = 5000000
 	clientTimeOutInSeconds     = 45
-	separator                  = "/"
 	retryMaxElapsedTimeMinutes = 15
 )
 
@@ -190,7 +189,7 @@ func (p *PasswordSafeProvider) Configure(ctx context.Context, req provider.Confi
 		url:                       strings.TrimSpace(data.Url.ValueString()),
 		apiVersion:                data.APIVersion.ValueString(),
 		accountname:               strings.TrimSpace(data.APIAccountName.ValueString()),
-		verifyca:                  data.VerifyCA.ValueBool(),
+		verifyca:                  data.VerifyCA.IsNull() || data.VerifyCA.ValueBool(),
 		clientCertificatePath:     data.ClientCertificatesFolderPath.ValueString(),
 		clientCertificateName:     data.ClientCertificateName.ValueString(),
 		clientCertificatePassword: data.ClientCertificatePassword.ValueString(),
@@ -233,7 +232,11 @@ func (p *PasswordSafeProvider) Configure(ctx context.Context, req provider.Confi
 	backoffDefinition.RandomizationFactor = 0.5
 
 	// creating a http client
-	httpClientObj, _ := utils.GetHttpClient(clientTimeOutInSeconds, providerData.verifyca, certificate, certificateKey, zapLogger)
+	httpClientObj, err := utils.GetHttpClient(clientTimeOutInSeconds, providerData.verifyca, certificate, certificateKey, zapLogger)
+	if err != nil {
+		resp.Diagnostics.AddError("Error creating HTTP client", err.Error())
+		return
+	}
 
 	var authenticate *auth.AuthenticationObj
 

--- a/providers/provider_framework/secrets_ephemeral.go
+++ b/providers/provider_framework/secrets_ephemeral.go
@@ -119,12 +119,13 @@ func (e *EphemeralSecret) Open(ctx context.Context, request ephemeral.OpenReques
 		return
 	}
 
+	sep := "/"
 	if data.Separator.ValueString() != "" {
-		separator = data.Separator.ValueString()
+		sep = data.Separator.ValueString()
 	}
 
 	// getting single secret from PS API
-	secret, err := secretObj.GetSecret(data.Path.ValueString()+separator+data.Title.ValueString(), separator)
+	secret, err := secretObj.GetSecret(data.Path.ValueString()+sep+data.Title.ValueString(), sep)
 
 	if err != nil {
 		response.Diagnostics.AddError("Error getting secret", err.Error())

--- a/providers/provider_framework/secrets_ephemeral_test.go
+++ b/providers/provider_framework/secrets_ephemeral_test.go
@@ -1,9 +1,11 @@
 package provider_framework
 
 import (
+	"fmt"
 	"net/http"
 	"net/http/httptest"
 	"regexp"
+	"sync"
 	"terraform-provider-passwordsafe/providers/constants"
 	"terraform-provider-passwordsafe/providers/entities"
 	"terraform-provider-passwordsafe/providers/utils"
@@ -143,6 +145,141 @@ func TestEphemeralSecret(t *testing.T) {
 			},
 		},
 	})
+}
+
+// TestEphemeralSecretCustomSeparator verifies that when the user provides a
+// non-default `separator` (here "|"), the ephemeral secret resource forwards
+// the same separator to the Password Safe API. The mock server asserts the
+// expected query parameters (path, title, separator) instead of using the
+// default "/" and returns a known value the test checks back through echo.
+func TestEphemeralSecretCustomSeparator(t *testing.T) {
+
+	customSeparator := "|"
+	expectedPath := "secret_path"
+	expectedTitle := "secret_title"
+
+	// handlerErr captures assertion failures from the HTTP handler goroutine.
+	// We cannot call t.Errorf/t.Error from a non-test goroutine because that
+	// can panic with "testing: t.Errorf called after test finished" or have
+	// the failure swallowed. Instead, store the error under handlerMu and
+	// assert it from the main test goroutine after resource.Test returns.
+	var (
+		handlerMu  sync.Mutex
+		handlerErr error
+	)
+	recordHandlerErr := func(err error) {
+		handlerMu.Lock()
+		defer handlerMu.Unlock()
+		// Only keep the first error to avoid losing the original cause.
+		if handlerErr == nil {
+			handlerErr = err
+		}
+	}
+
+	// mocking Password Safe API
+	server := httptest.NewTLSServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+
+		// mocking Response according to the endpoint path
+		switch r.URL.Path {
+		case constants.APIPath + "/Auth/connect/token":
+			_, err := w.Write([]byte(`{"access_token": "fake_token", "expires_in": 600, "token_type": "Bearer", "scope": "publicapi"}`))
+			if err != nil {
+				recordHandlerErr(err)
+			}
+
+		case constants.APIPath + "/Auth/SignAppIn":
+			_, err := w.Write([]byte(`{"UserId":1, "EmailAddress":"test@beyondtrust.com"}`))
+
+			if err != nil {
+				recordHandlerErr(err)
+			}
+
+		case constants.APIPath + "/secrets-safe/secrets":
+			// Assert the custom separator was forwarded to the API. The
+			// underlying client library passes path, title and separator
+			// as query parameters; if the provider had hard-coded "/" the
+			// separator value would not match.
+			query := r.URL.Query()
+			if got := query.Get("separator"); got != customSeparator {
+				recordHandlerErr(fmt.Errorf("expected separator=%q in request, got %q", customSeparator, got))
+			}
+			if got := query.Get("path"); got != expectedPath {
+				recordHandlerErr(fmt.Errorf("expected path=%q in request, got %q", expectedPath, got))
+			}
+			if got := query.Get("title"); got != expectedTitle {
+				recordHandlerErr(fmt.Errorf("expected title=%q in request, got %q", expectedTitle, got))
+			}
+			_, err := w.Write([]byte(`[{"SecretType": "SECRET", "Password": "fake_password_custom_sep","Id": "9152f5b6-07d6-4955-175a-08db047219ce","Title": "credential_in_sub_3"}]`))
+			if err != nil {
+				recordHandlerErr(err)
+			}
+
+		case constants.APIPath + "/Auth/Signout":
+			_, err := w.Write([]byte(``))
+			if err != nil {
+				recordHandlerErr(err)
+			}
+		}
+
+	}))
+
+	server.URL = server.URL + constants.APIPath
+
+	customSepConfig := entities.PasswordSafeTestConfig{
+		ClientID:                     constants.FakeClientId,
+		ClientSecret:                 constants.FakeClientSecret,
+		URL:                          server.URL,
+		APIAccountName:               "",
+		ClientCertificatesFolderPath: "",
+		ClientCertificateName:        "",
+		ClientCertificatePassword:    "",
+		APIVersion:                   "3.1",
+		Resource: `
+		ephemeral "passwordsafe_secret_ephemeral" "test" {
+		title = "secret_title"
+		path = "secret_path"
+		separator = "|"
+		}
+
+		provider "echo" {
+		data = ephemeral.passwordsafe_secret_ephemeral.test
+		}
+
+		resource "echo" "test" {}`,
+	}
+
+	resource.Test(t, resource.TestCase{
+
+		TerraformVersionChecks: []tfversion.TerraformVersionCheck{
+			tfversion.SkipBelow(tfversion.Version1_10_0),
+		},
+		PreCheck: func() {},
+		ProtoV6ProviderFactories: map[string]func() (tfprotov6.ProviderServer, error){
+			"passwordsafe": providerserver.NewProtocol6WithError(NewProvider()),
+			"echo":         echoprovider.NewProviderServer(),
+		},
+		Steps: []resource.TestStep{
+			{
+				Config: utils.TestResourceConfig(customSepConfig),
+				ConfigStateChecks: []statecheck.StateCheck{
+					statecheck.ExpectKnownValue(
+						"echo.test",
+						tfjsonpath.New("data").AtMapKey("value"),
+						knownvalue.StringExact("fake_password_custom_sep"),
+					),
+				},
+			},
+		},
+	})
+
+	// Surface any assertion error captured by the HTTP handler goroutine
+	// from the main test goroutine. This avoids the "t.Errorf called after
+	// test finished" panic and ensures the failure is not swallowed.
+	handlerMu.Lock()
+	defer handlerMu.Unlock()
+	if handlerErr != nil {
+		t.Errorf("HTTP handler assertion failed: %v", handlerErr)
+	}
 }
 
 func TestEphemeralSecretNotFound(t *testing.T) {

--- a/providers/provider_sdkv2/common.go
+++ b/providers/provider_sdkv2/common.go
@@ -137,12 +137,14 @@ func getManagedAccountSchema() map[string]*schema.Schema {
 			Optional: true,
 		},
 		"private_key": &schema.Schema{
-			Type:     schema.TypeString,
-			Optional: true,
+			Type:      schema.TypeString,
+			Optional:  true,
+			Sensitive: true,
 		},
 		"passphrase": &schema.Schema{
-			Type:     schema.TypeString,
-			Optional: true,
+			Type:      schema.TypeString,
+			Optional:  true,
+			Sensitive: true,
 		},
 		"password_fallback_flag": &schema.Schema{
 			Type:     schema.TypeBool,

--- a/providers/provider_sdkv2/managed_account_test.go
+++ b/providers/provider_sdkv2/managed_account_test.go
@@ -455,3 +455,25 @@ func TestResourceManagedAccountDeleteAuthenticationError(t *testing.T) {
 		t.Errorf("Expected authentication error when passing nil authentication object, but got nil")
 	}
 }
+
+// TestGetManagedAccountSchemaSensitiveFields guards against regressions where a
+// secret-bearing attribute on the managed_account schema accidentally drops the
+// Sensitive flag. password (the historical reference) plus private_key and
+// passphrase must all be marked Sensitive so Terraform never logs or echoes
+// their values in plan/apply output.
+func TestGetManagedAccountSchemaSensitiveFields(t *testing.T) {
+	managedAccountSchema := getManagedAccountSchema()
+
+	sensitiveAttributes := []string{"password", "private_key", "passphrase"}
+
+	for _, attrName := range sensitiveAttributes {
+		attr, ok := managedAccountSchema[attrName]
+		if !ok {
+			t.Errorf("Expected schema attribute %q to exist on managed_account schema", attrName)
+			continue
+		}
+		if !attr.Sensitive {
+			t.Errorf("Expected schema attribute %q to be marked Sensitive=true, got Sensitive=%v", attrName, attr.Sensitive)
+		}
+	}
+}

--- a/providers/provider_sdkv2/provider.go
+++ b/providers/provider_sdkv2/provider.go
@@ -142,6 +142,24 @@ func ValidateCredentialsAndConfig(apikey string, clientId string, clientSecret s
 }
 
 // Provider Init Config.
+func buildAuthenticationObj(httpClient utils.HttpClientObj, backoffDefinition *backoff.ExponentialBackOff, apikey, url, apiVersion, accountName, clientId, clientSecret string, retryMaxElapsedTimeMinutes int) (*auth.AuthenticationObj, error) {
+	base := auth.AuthenticationParametersObj{
+		HTTPClient:                 httpClient,
+		BackoffDefinition:          backoffDefinition,
+		EndpointURL:                url,
+		APIVersion:                 apiVersion,
+		Logger:                     zapLogger,
+		RetryMaxElapsedTimeSeconds: retryMaxElapsedTimeMinutes,
+	}
+	if apikey != "" {
+		base.ApiKey = fmt.Sprintf("%v;runas=%v;", apikey, accountName)
+		return auth.AuthenticateUsingApiKey(base)
+	}
+	base.ClientID = clientId
+	base.ClientSecret = clientSecret
+	return auth.Authenticate(base)
+}
+
 func providerConfigure(ctx context.Context, d *schema.ResourceData) (interface{}, diag.Diagnostics) {
 
 	apikey := d.Get("api_key").(string)
@@ -210,39 +228,7 @@ func providerConfigure(ctx context.Context, d *schema.ResourceData) (interface{}
 		return nil, diag.FromErr(err)
 	}
 
-	// If this variable is set, we're using API Key authentication
-	// (previous/old authentication method)
-	if apikey != "" {
-		authParamsApiKey := &auth.AuthenticationParametersObj{
-			HTTPClient:                 *httpClientObj,
-			BackoffDefinition:          backoffDefinition,
-			EndpointURL:                url,
-			APIVersion:                 apiVersion,
-			ClientID:                   "",
-			ClientSecret:               "",
-			ApiKey:                     fmt.Sprintf("%v;runas=%v;", apikey, accountName),
-			Logger:                     zapLogger,
-			RetryMaxElapsedTimeSeconds: retryMaxElapsedTimeMinutes,
-		}
-		authenticate, err := auth.AuthenticateUsingApiKey(*authParamsApiKey)
-		if err != nil {
-			return nil, diag.FromErr(err)
-		}
-		return authenticate, diags
-	}
-
-	authParamsOauth := &auth.AuthenticationParametersObj{
-		HTTPClient:                 *httpClientObj,
-		BackoffDefinition:          backoffDefinition,
-		EndpointURL:                url,
-		APIVersion:                 apiVersion,
-		ClientID:                   clientId,
-		ClientSecret:               clientSecret,
-		ApiKey:                     "",
-		Logger:                     zapLogger,
-		RetryMaxElapsedTimeSeconds: retryMaxElapsedTimeMinutes,
-	}
-	authenticate, err := auth.Authenticate(*authParamsOauth)
+	authenticate, err := buildAuthenticationObj(*httpClientObj, backoffDefinition, apikey, url, apiVersion, accountName, clientId, clientSecret, retryMaxElapsedTimeMinutes)
 	if err != nil {
 		return nil, diag.FromErr(err)
 	}

--- a/providers/provider_sdkv2/provider.go
+++ b/providers/provider_sdkv2/provider.go
@@ -202,7 +202,7 @@ func providerConfigure(ctx context.Context, d *schema.ResourceData) (interface{}
 	errorsInInputs := utils.ValidateInputs(params)
 
 	if errorsInInputs != nil {
-		return nil, diag.FromErr(err)
+		return nil, diag.FromErr(errorsInInputs)
 	}
 
 	httpClientObj, err := utils.GetHttpClient(45, verifyca, certificate, certificateKey, zapLogger)

--- a/providers/provider_sdkv2/provider_test.go
+++ b/providers/provider_sdkv2/provider_test.go
@@ -4,6 +4,8 @@ import (
 	"context"
 	"testing"
 
+	"terraform-provider-passwordsafe/providers/constants"
+
 	"github.com/hashicorp/terraform-plugin-sdk/v2/helper/schema"
 	"github.com/stretchr/testify/assert"
 )
@@ -18,10 +20,10 @@ func TestProvider(t *testing.T) {
 
 func TestProviderConfigureWithApiKey(t *testing.T) {
 	resourceData := schema.TestResourceDataRaw(t, Provider().Schema, map[string]interface{}{
-		"url":                             "https://example.com",
+		"url":                             constants.FakeApiUrl,
 		"api_account_name":                "test-account",
-		"client_id":                       "test-client-id",
-		"client_secret":                   "test-client-secret",
+		"client_id":                       "",
+		"client_secret":                   "",
 		"api_key":                         "test-api-key",
 		"verify_ca":                       true,
 		"client_certificate_name":         "",
@@ -37,10 +39,10 @@ func TestProviderConfigureWithApiKey(t *testing.T) {
 
 func TestProviderConfigureWithCredentials(t *testing.T) {
 	resourceData := schema.TestResourceDataRaw(t, Provider().Schema, map[string]interface{}{
-		"url":                             "https://example.com",
+		"url":                             constants.FakeApiUrl,
 		"api_account_name":                "test-account",
-		"client_id":                       "test-client-id",
-		"client_secret":                   "test-client-secret",
+		"client_id":                       "00000000-0000-0000-0000-000000000001",
+		"client_secret":                   "00000000-0000-0000-0000-000000000002",
 		"api_key":                         "",
 		"verify_ca":                       true,
 		"client_certificate_name":         "",


### PR DESCRIPTION
## Summary

- **BIPS-35997**: Fix wrong error variable in SDKv2 provider validation — `diag.FromErr(err)` was using `err` (nil when no certificate path taken) instead of `errorsInInputs`, silently swallowing validation failures
- **BIPS-35987**: Mark `private_key` and `passphrase` as `Sensitive: true` in SDKv2 managed account schema so they are masked in `terraform plan` / `apply` output
- **BIPS-35972**: Default `verify_ca` to `true` when omitted in the framework provider — Plugin Framework returns `false` for null bools, so omitting the field was silently disabling TLS certificate verification
- **BIPS-35993**: Handle `GetHttpClient()` error in framework provider `Configure()` instead of discarding it with `_`, preventing silent nil-pointer panics on bad certificate config
- **BIPS-35966**: Replace package-level `separator` variable with a local variable inside `EphemeralSecret.Open()` to eliminate a data race when multiple ephemeral secret resources run concurrently with different separators

## Test plan

- [x] All packages build cleanly (`go build ./...`)
- [x] All unit tests pass (`TF_ACC=1 go test ./providers/...`)
- [x] Manual end-to-end tests with a new provider build confirmed all 5 fixes behave as expected against a live Password Safe instance

🤖 Generated with [Claude Code](https://claude.com/claude-code)