### PR TITLE
fix: release pipeline corrections [DX-4896]

### DIFF
--- a/.github/actions/setup-terraform/action.yml
+++ b/.github/actions/setup-terraform/action.yml
@@ -14,4 +14,3 @@ runs:
       uses: hashicorp/setup-terraform@dfe3c3f87815947d99a8997f908cb6525fc44e9e # v4.0.1
       with:
         terraform_version: ${{ steps.terraform-version.outputs.version }}
-        terraform_wrapper: false

--- a/.github/security-policy.yml
+++ b/.github/security-policy.yml
@@ -1,19 +1,9 @@
-# GHAS Policy as Code — remediation SLA policy.
-# Reference: https://github.com/advanced-security/policy-as-code
+# GHAS Policy as Code — remediation SLA for the `security-gate` action (Code Scanning only).
+# https://github.com/advanced-security/policy-as-code
 #
-# Consumed by the `security-gate` composite action, which fails a build/release when an
-# open alert has been open longer than the SLA (in days) for its severity (zero
-# tolerance once past SLA). Alerts still within their window do not block.
-#
-# Settings live in `general` so they apply to every enabled check. Only Code Scanning is
-# enabled in the gate — Dependabot, secret-scanning and dependency/licensing are disabled
-# there (they require a GitHub App/PAT to read).
-#
-# SLA (max age in days): critical 10 | high 15 | medium 20 | low 90
+# critical/high block a release immediately (default `error` severity); medium/low block
+# only once open past their SLA window (days) below.
 general:
-  # `low` scopes the gate to the four security severities below; the remediate windows
-  # decide what blocks, so nothing fails for existing — only for being past SLA.
-  level: low
   remediate:
     critical: 10
     high: 15

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -1,27 +1,16 @@
 name: Release
 
-# Release pipeline. release-please keeps a release PR up to date on every push to
-# main (version bump + CHANGELOG). When that PR is merged, release-please creates
-# the git tag and a DRAFT GitHub release; GoReleaser then builds and GPG-signs the
-# artifacts and uploads them to that release; finally the release is published,
-# which is what the Terraform Registry webhook ingests.
-#
-# Everything runs as dependent jobs in a SINGLE workflow run, so the release does
-# not rely on the tag push triggering a separate workflow (events created with the
-# default GITHUB_TOKEN do not trigger other workflows) — no PAT or GitHub App token
-# is required.
-#
-# Reference: https://developer.hashicorp.com/terraform/registry/providers/publishing
+# release-please maintains a release PR; merging it tags a draft release, GoReleaser
+# signs and uploads artifacts, then publish flips it out of draft for the Terraform
+# Registry webhook. All in one run so no PAT is needed to chain off the tag push.
+# https://developer.hashicorp.com/terraform/registry/providers/publishing
 
 on:
   push:
     branches:
       - main
 
-# Serialize releases: only one release pipeline runs at a time. cancel-in-progress is
-# false so a newer push queues behind the in-flight run instead of cancelling it — a
-# cancelled run can leave a partially-populated draft release/tag, and overlapping runs
-# could race on the same draft release/tag.
+# Serialize releases; queue newer pushes rather than cancel (a half-done draft/tag is worse).
 concurrency:
   group: ${{ github.workflow }}-${{ github.ref }}
   cancel-in-progress: false
@@ -107,22 +96,15 @@ jobs:
           GPG_FINGERPRINT: ${{ steps.import_gpg.outputs.fingerprint }}
 
       - name: Attest build provenance
-        # Signed SLSA provenance for the published zips AND the SHA256SUMS manifest —
-        # the checksum file is the integrity anchor consumers verify against, so it is
-        # attested too (verify with `gh attestation verify <file> --repo <owner>/<repo>`).
-        # Supplementary to the GPG signature the Terraform Registry verifies.
+        # SLSA provenance for the zips and the SHA256SUMS manifest consumers verify against.
         uses: actions/attest-build-provenance@a2bbfa25375fe432b6a289bc6b6cd05ecd0c4c32 # v4.1.0
         with:
           subject-path: |
             dist/*.zip
             dist/*_SHA256SUMS
 
-  # GitHub's Dependency Graph REST API returns an SPDX 2.3 SBOM directly;
-  # the advanced-security/sbom-generator-action wrapper is deprecated in favor of this
-  # endpoint. Note: this is a DEPENDENCY-GRAPH SBOM (the default branch's resolved
-  # dependencies), not a build-time SBOM of the compiled binaries — it reflects what the
-  # module depends on, not a per-artifact bill of materials. It is best-effort and never
-  # blocks publish (see the publish job's `if`).
+  # Dependency-graph SBOM (resolved module deps, not a per-artifact BOM). Best-effort:
+  # never blocks publish (see the publish job's `if`).
   sbom:
     name: Generate SBOM
     runs-on: ubuntu-latest
@@ -130,7 +112,7 @@ jobs:
     needs: [release-please, goreleaser]
     if: needs.release-please.outputs.release_created == 'true'
     permissions:
-      contents: write  # read the dependency graph and attach the SBOM to the release
+      contents: read  # read the dependency graph to generate the SBOM
     steps:
       - name: Generate SBOM
         id: sbom
@@ -145,31 +127,28 @@ jobs:
           GITHUB_TOKEN: ${{ github.token }}
           TAG_NAME: ${{ needs.release-please.outputs.tag_name }}
 
-      - name: Attach SBOM to draft release
-        run: gh release upload --clobber "$TAG_NAME" "${{ steps.sbom.outputs.file }}"
-        env:
-          GITHUB_TOKEN: ${{ github.token }}
-          TAG_NAME: ${{ needs.release-please.outputs.tag_name }}
+      - name: Upload SBOM as workflow artifact
+        # Not a release asset: the Terraform Registry rejects a release with a *.spdx.json
+        # ("invalid file extension found (.json)"), so keep the SBOM on the run instead.
+        uses: actions/upload-artifact@ea165f8d65b6e75b540449e92b4886f43607fa02 # v4.6.2
+        with:
+          name: sbom
+          path: ${{ steps.sbom.outputs.file }}
+          retention-days: 90
+          if-no-files-found: error
 
   publish:
     name: Publish Release
     runs-on: ubuntu-latest
     timeout-minutes: 5
-    needs: [release-please, goreleaser, sbom]
-    # Runs after sbom for ordering, but the SBOM is best-effort: publish proceeds
-    # even if sbom failed, as long as the signed artifacts (goreleaser) are present.
-    if: >-
-      always() &&
-      needs.release-please.outputs.release_created == 'true' &&
-      needs.goreleaser.result == 'success'
+    # Not gated on sbom: it's a workflow artifact, so it runs in parallel and never blocks publish.
+    needs: [release-please, goreleaser]
+    if: needs.release-please.outputs.release_created == 'true'
     permissions:
       contents: write  # flip the release out of draft
     steps:
       - name: Publish GitHub release
-        # Signed artifacts and checksums (and the SBOM, when it succeeded) are now
-        # attached. Flipping the release out of draft fires the "release: published"
-        # event that the Terraform Registry webhook listens for, so the registry
-        # ingests a complete release in a single pass.
+        # Flips the draft out, firing the "release: published" event the Registry ingests.
         run: gh release edit "$TAG_NAME" --repo "$GITHUB_REPOSITORY" --draft=false --latest
         env:
           GITHUB_TOKEN: ${{ github.token }}

--- a/.goreleaser.yml
+++ b/.goreleaser.yml
@@ -9,9 +9,7 @@ before:
 
 builds:
   - env:
-      # goreleaser does not work with CGO, it could also complicate
-      # usage by users in CI/CD systems like Terraform Cloud where
-      # they are unable to install libraries.
+      # CGO off: portable static binaries for Terraform Cloud and other CI.
       - CGO_ENABLED=0
     mod_timestamp: '{{ .CommitTimestamp }}'
     flags:
@@ -53,22 +51,21 @@ checksum:
 signs:
   - artifacts: checksum
     args:
-      # if you are using this in a GitHub action or some other automated pipeline, you
-      # need to pass the batch flag to indicate its not interactive.
       - "--batch"
       - "--local-user"
-      - "{{ .Env.GPG_FINGERPRINT }}" # set this environment variable for your signing key
+      - "{{ .Env.GPG_FINGERPRINT }}"
       - "--output"
       - "${signature}"
       - "--detach-sign"
       - "${artifact}"
 
 release:
-  # Keep the release in draft; the Release workflow's `publish` job flips it out of
-  # draft once every artifact (and the SBOM) is attached, so the Terraform Registry
-  # webhook only fires for a complete release.
+  # Stay in draft; the workflow's publish job flips it out once artifacts are attached.
   draft: true
-  # release-please owns the release notes (CHANGELOG); keep its body untouched.
+  # Upload into release-please's existing draft; without this GoReleaser 404s on the
+  # get-release-by-tag lookup (drafts aren't returned) and creates a duplicate.
+  use_existing_draft: true
+  # release-please owns the release notes; keep its body untouched.
   mode: keep-existing
   extra_files:
     - glob: 'terraform-registry-manifest.json'


### PR DESCRIPTION
## Summary

Corrects the release pipeline so a tagged release publishes cleanly to the Terraform Registry, and trims the verbose CI comments. Ports the proven behaviors from `terraform-provider-beyondtrust`.

Jira: https://beyondtrust.atlassian.net/browse/DX-4896

## Changes

**`.goreleaser.yml`**
- Add `use_existing_draft: true` so GoReleaser uploads artifacts **into** the release-please draft. Without it, GoReleaser 404s on the get-release-by-tag lookup (drafts aren't returned) and creates a duplicate draft, stranding the signed artifacts away from the release-please release.

**`.github/workflows/release.yml`**
- SBOM is now uploaded as a **workflow artifact** instead of attached to the release. The Terraform Registry rejects a release containing a `*.spdx.json` ("invalid file extension found (.json)"); keeping it on the run preserves the SBOM without breaking ingestion.
- Drop the `sbom` job's permission from `contents: write` to `contents: read` (it no longer touches the release).
- Decouple `publish` from `sbom` — `publish` now needs only `release-please` and `goreleaser`, so the best-effort SBOM runs in parallel and can never block publishing. This also removes the `always()` / `goreleaser.result` workaround that only existed to tolerate a failed SBOM.

**`.github/actions/setup-terraform/action.yml`**
- Remove `terraform_wrapper: false`.

**`.github/security-policy.yml`**
- Remove the explicit `level`; critical/high now block a release immediately (default `error` severity) while medium/low gate on SLA age.

**Comment cleanup**
- Condense the multi-line explanatory comment blocks across the above files to single-line rationale.